### PR TITLE
feat: Add normalized flow

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -11,6 +11,6 @@ export default {
   },
   testPathIgnorePatterns: ["dist/*"],
   collectCoverage: true,
-  coverageReporters: ["lcov", "text-summary"],
+  coverageReporters: ["html", "lcov", "text-summary"],
   coverageDirectory: "./coverage",
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build": "rimraf ./types ./dist && tsc",
     "lint": "eslint 'src/**/*.{js,ts}'",
     "test": "jest",
-    "check": "tsc --noEmit && pnpm lint",
+    "check": "tsc --project ./tsconfig.check.json && pnpm lint",
     "prepare": "pnpm i rimraf && pnpm build"
   },
   "dependencies": {

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -1,0 +1,95 @@
+import {
+  typeEnumToString,
+  stringToTypeEnum,
+  clearUndefinedKeys,
+} from "./helpers";
+import { ComponentType } from "./types";
+
+describe("clearUndefinedKeys", () => {
+  test("undefined keys are removed from an object", () => {
+    const obj = {
+      one: {
+        1: {
+          i: undefined,
+          ii: null,
+          iii: "3",
+        },
+      },
+      two: undefined,
+      three: {
+        A: undefined,
+        B: "b",
+        C: undefined,
+      },
+    };
+    clearUndefinedKeys(obj);
+    expect(obj).toStrictEqual({
+      one: {
+        1: {
+          ii: null,
+          iii: "3",
+        },
+      },
+      three: {
+        B: "b",
+      },
+    });
+  });
+  test("it does nothing when passed a non-object", () => {
+    expect(() => {
+      clearUndefinedKeys("not an object");
+    }).not.toThrow();
+  });
+});
+
+describe("typeEnumToString", () => {
+  test("ComponentType values are mapped to a component type string", () => {
+    const expectationMap: [number, string][] = [
+      [100, "Question"],
+      [200, "Answer"],
+      [3, "Result"],
+      [725, "Confirmation"],
+    ];
+    for (const [input, expected] of expectationMap) {
+      expect(typeEnumToString(input)).toEqual(expected);
+    }
+  });
+
+  test("ComponentTypes are converted to a string", () => {
+    const expectationMap: [ComponentType, string][] = [
+      [ComponentType.Question, "Question"],
+      [ComponentType.Answer, "Answer"],
+      [ComponentType.Result, "Result"],
+      [ComponentType.Confirmation, "Confirmation"],
+    ];
+    for (const [input, expected] of expectationMap) {
+      expect(typeEnumToString(input)).toEqual(expected);
+    }
+  });
+
+  test("an unsupported ComponentType throws an error", () => {
+    expect(() => {
+      typeEnumToString(999);
+    }).toThrow();
+  });
+});
+
+describe("stringToTypeEnum", () => {
+  test("strings are mapped to a ComponentType", () => {
+    const expectationMap: [string, ComponentType][] = [
+      ["Question", ComponentType.Question],
+      ["Answer", ComponentType.Answer],
+      ["Result", ComponentType.Result],
+      ["Confirmation", ComponentType.Confirmation],
+    ];
+    for (const [input, expected] of expectationMap) {
+      expect(stringToTypeEnum(input)).toEqual(expected);
+    }
+  });
+
+  test("an unsupported string throws an error", () => {
+    expect(() => {
+      stringToTypeEnum("unknownComponentType");
+    }).toThrow();
+  });
+});

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,30 @@
+import { ComponentType } from "./types";
+
+export function clearUndefinedKeys(input: unknown) {
+  if (typeof input != "object") return;
+  const obj = input as { [key: string]: unknown };
+  Object.keys(obj).forEach((key: string) => {
+    if (obj[key] === undefined) delete obj[key];
+    if (obj[key] && typeof obj[key] == "object") {
+      clearUndefinedKeys(obj[key]);
+    }
+  });
+}
+
+export function typeEnumToString(
+  componentType: ComponentType | number
+): string {
+  // a numeric enum has a reverese mapping to its name
+  const name = ComponentType[componentType];
+  if (name) return name;
+  throw new Error(`"${componentType}" is not a valid ComponentType`);
+}
+
+export function stringToTypeEnum(componentTypeString: string): ComponentType {
+  for (const [key, value] of Object.entries(ComponentType)) {
+    if (key == componentTypeString) {
+      return value as ComponentType;
+    }
+  }
+  throw new Error(`"${componentTypeString}" is not a valid ComponentType`);
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,9 @@
-import { CoreDomainClient, sortFlow, sortBreadcrumbs } from "./index";
+import {
+  CoreDomainClient,
+  sortFlow,
+  normalizeFlow,
+  enrichBreadcrumbs,
+} from "./index";
 
 describe("CoreDomainClient", () => {
   test("instantiating a client without any arguments", () => {
@@ -26,11 +31,15 @@ describe("CoreDomainClient", () => {
 });
 
 describe("Logic", () => {
-  test("sortFlow is rexported from ./logic", () => {
+  test("sortFlow is available", () => {
     expect(typeof sortFlow).toBe("function");
   });
 
-  test("sortBreadcrumbs is rexported from ./logic", () => {
-    expect(typeof sortBreadcrumbs).toBe("function");
+  test("normalizeFlow is available", () => {
+    expect(typeof normalizeFlow).toBe("function");
+  });
+
+  test("enrichBreadcrumbs is available", () => {
+    expect(typeof enrichBreadcrumbs).toBe("function");
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,17 +9,20 @@ import { getDocumentTemplateNames } from "./document-templates";
 const defaultURL = process.env.HASURA_GRAPHQL_URL;
 
 export * from "./logic";
+export { ComponentType } from "./types";
 export type {
-  ComponentType,
+  NodeId,
   Edges,
+  Value,
   Node,
-  Flow,
   IndexedNode,
   OrderedFlow,
+  NormalizedNode,
+  NormalizedFlow,
   Crumb,
-  EnrichedCrumb,
   Breadcrumbs,
-  OrderedBreadcrumbs,
+  EnrichedCrumb,
+  EnrichedBreadcrumbs,
 } from "./types";
 
 export class CoreDomainClient {

--- a/src/logic.test.ts
+++ b/src/logic.test.ts
@@ -19,7 +19,7 @@ describe("sortFlow", () => {
 
   test("it sorts a complex graph of nodes into an ordered array", () => {
     const sortedFlowNodes: OrderedFlow = sortFlow(complex.flow);
-    expect(sortedFlowNodes.length).toBe(28);
+    expect(sortedFlowNodes.length).toBe(27);
     expect(sortedFlowNodes).toEqual(complex.orderedFlow);
   });
 
@@ -53,12 +53,12 @@ describe("enrichBreadcrumbs", () => {
     expect(enrichedBreadcrumbs).toEqual(sectioned.enrichedBreadcrumbs);
   });
 
-  test.skip("it sorts breadcrumbs in complex flows", () => {
+  test("it sorts breadcrumbs in complex flows", () => {
     const enrichedBreadcrumbs: EnrichedBreadcrumbs = enrichBreadcrumbs(
       complex.flow,
       complex.breadcrumbs
     );
-    expect(enrichedBreadcrumbs.length).toBe(6);
+    expect(enrichedBreadcrumbs.length).toBe(7);
     expect(enrichedBreadcrumbs).toEqual(complex.enrichedBreadcrumbs);
   });
 });
@@ -78,7 +78,7 @@ describe("normalizeFlow", () => {
 
   test("it sorts a complex graph of nodes into an normalized array", () => {
     const normalizedFlowNodes: NormalizedFlow = normalizeFlow(complex.flow);
-    expect(normalizedFlowNodes.length).toBe(28);
+    expect(normalizedFlowNodes.length).toBe(27);
     expect(normalizedFlowNodes).toEqual(complex.normalizedFlow);
   });
 });

--- a/src/logic.test.ts
+++ b/src/logic.test.ts
@@ -1,52 +1,84 @@
-import { sortBreadcrumbs, sortFlow } from "./logic";
+import { sortFlow, normalizeFlow, enrichBreadcrumbs } from "./logic";
 import * as sectioned from "./mocks/section-flow-breadcrumbs";
 import * as simple from "./mocks/simple-flow-breadcrumbs";
 import * as complex from "./mocks/complex-flow-breadcrumbs";
-import type { OrderedBreadcrumbs, OrderedFlow } from "./types";
+import type { OrderedFlow, NormalizedFlow, EnrichedBreadcrumbs } from "./types";
 
 describe("sortFlow", () => {
   test("it sorts a simple graph of nodes into an ordered array", () => {
     const sortedFlowNodes: OrderedFlow = sortFlow(simple.flow);
-
     expect(sortedFlowNodes.length).toBe(6);
     expect(sortedFlowNodes).toEqual(simple.orderedFlow);
   });
 
   test("it sorts a graph with sections into an ordered array", () => {
     const sortedFlowNodes: OrderedFlow = sortFlow(sectioned.flow);
-
     expect(sortedFlowNodes.length).toBe(9);
     expect(sortedFlowNodes).toEqual(sectioned.orderedFlow);
   });
 
   test("it sorts a complex graph of nodes into an ordered array", () => {
     const sortedFlowNodes: OrderedFlow = sortFlow(complex.flow);
-
-    expect(sortedFlowNodes.length).toBe(27);
+    expect(sortedFlowNodes.length).toBe(28);
     expect(sortedFlowNodes).toEqual(complex.orderedFlow);
+  });
+
+  test("corrupted flows throw an error", () => {
+    expect(() => {
+      sortFlow({
+        _root: {
+          edges: ["doesnt-exist"],
+        },
+      });
+    }).toThrow();
   });
 });
 
-describe("sortBreadcrumbs", () => {
+describe("enrichBreadcrumbs", () => {
   test("it sorts breadcrumbs in simple flows", () => {
-    const orderedBreadcrumbs: OrderedBreadcrumbs = sortBreadcrumbs(
+    const enrichedBreadcrumbs: EnrichedBreadcrumbs = enrichBreadcrumbs(
       simple.flow,
       simple.breadcrumbs
     );
-
-    expect(orderedBreadcrumbs.length).toBe(3);
-    expect(orderedBreadcrumbs).toEqual(simple.orderedBreadcrumbs);
+    expect(enrichedBreadcrumbs.length).toBe(3);
+    expect(enrichedBreadcrumbs).toEqual(simple.enrichedBreadcrumbs);
   });
 
   test("it sorts breadcrumbs in flows with sections", () => {
-    const orderedBreadcrumbs: OrderedBreadcrumbs = sortBreadcrumbs(
+    const enrichedBreadcrumbs: EnrichedBreadcrumbs = enrichBreadcrumbs(
       sectioned.flow,
       sectioned.breadcrumbs
     );
-
-    expect(orderedBreadcrumbs.length).toBe(6);
-    expect(orderedBreadcrumbs).toEqual(sectioned.orderedBreadcrumbs);
+    expect(enrichedBreadcrumbs.length).toBe(6);
+    expect(enrichedBreadcrumbs).toEqual(sectioned.enrichedBreadcrumbs);
   });
 
-  test.todo("it sorts breadcrumbs in complex flows");
+  test.skip("it sorts breadcrumbs in complex flows", () => {
+    const enrichedBreadcrumbs: EnrichedBreadcrumbs = enrichBreadcrumbs(
+      complex.flow,
+      complex.breadcrumbs
+    );
+    expect(enrichedBreadcrumbs.length).toBe(6);
+    expect(enrichedBreadcrumbs).toEqual(complex.enrichedBreadcrumbs);
+  });
+});
+
+describe("normalizeFlow", () => {
+  test("it sorts a simple graph of nodes into an normalized array", () => {
+    const normalizedFlowNodes: NormalizedFlow = normalizeFlow(simple.flow);
+    expect(normalizedFlowNodes.length).toBe(6);
+    expect(normalizedFlowNodes).toEqual(simple.normalizedFlow);
+  });
+
+  test("it sorts a graph with sections into an normalized array", () => {
+    const normalizedFlowNodes: NormalizedFlow = normalizeFlow(sectioned.flow);
+    expect(normalizedFlowNodes.length).toBe(9);
+    expect(normalizedFlowNodes).toEqual(sectioned.normalizedFlow);
+  });
+
+  test("it sorts a complex graph of nodes into an normalized array", () => {
+    const normalizedFlowNodes: NormalizedFlow = normalizeFlow(complex.flow);
+    expect(normalizedFlowNodes.length).toBe(28);
+    expect(normalizedFlowNodes).toEqual(complex.normalizedFlow);
+  });
 });

--- a/src/logic.ts
+++ b/src/logic.ts
@@ -2,7 +2,7 @@ import { ComponentType } from "./types";
 import { typeEnumToString, clearUndefinedKeys } from "./helpers";
 import type {
   IndexedNode,
-  Flow,
+  FlowGraph,
   OrderedFlow,
   NormalizedNode,
   NormalizedFlow,
@@ -12,7 +12,7 @@ import type {
   EnrichedBreadcrumbs,
 } from "./types";
 
-export function sortFlow(flow: Flow): OrderedFlow {
+export function sortFlow(flow: FlowGraph): OrderedFlow {
   const nodes = new Set<IndexedNode>([]);
   const searchNodeEdges = (id: string, parentId?: string) => {
     const foundNode = flow[id];
@@ -36,7 +36,7 @@ export function sortFlow(flow: Flow): OrderedFlow {
   return [...nodes];
 }
 
-export function normalizeFlow(flow: Flow): NormalizedFlow {
+export function normalizeFlow(flow: FlowGraph): NormalizedFlow {
   let currentSectionId: string;
   let rootNodeId: string;
   return sortFlow(flow).map((node: IndexedNode) => {
@@ -64,7 +64,7 @@ export function normalizeFlow(flow: Flow): NormalizedFlow {
 }
 
 export function enrichBreadcrumbs(
-  flow: Flow,
+  flow: FlowGraph,
   breadcrumbs: Breadcrumbs
 ): EnrichedBreadcrumbs {
   const normalizedFlow: NormalizedFlow = normalizeFlow(flow);

--- a/src/logic.ts
+++ b/src/logic.ts
@@ -1,61 +1,99 @@
+import { ComponentType } from "./types";
+import { typeEnumToString, clearUndefinedKeys } from "./helpers";
 import type {
   IndexedNode,
   Flow,
   OrderedFlow,
+  NormalizedNode,
+  NormalizedFlow,
   Crumb,
-  EnrichedCrumb,
-  OrderedBreadcrumbs,
   Breadcrumbs,
+  EnrichedCrumb,
+  EnrichedBreadcrumbs,
 } from "./types";
-import { ComponentType } from "./types";
 
 export function sortFlow(flow: Flow): OrderedFlow {
   const nodes = new Set<IndexedNode>([]);
-  const searchNodeEdges = (id: string) => {
+  const searchNodeEdges = (id: string, parentId?: string) => {
     const foundNode = flow[id];
     if (!foundNode) {
       throw new Error(`Referenced node edge "${id}" not found`);
     }
-    nodes.add({ id: id, ...foundNode });
+    nodes.add({
+      id,
+      parentId: parentId || null,
+      ...foundNode,
+    });
     flow[id].edges?.forEach((childEdgeId) => {
-      searchNodeEdges(childEdgeId);
+      searchNodeEdges(childEdgeId, id);
     });
   };
+  let parentId: string;
   flow._root.edges.forEach((rootEdgeId) => {
-    searchNodeEdges(rootEdgeId);
+    searchNodeEdges(rootEdgeId, parentId);
+    parentId = rootEdgeId;
   });
   return [...nodes];
 }
 
-export function sortBreadcrumbs(
-  flow: Flow,
-  breadcrumbs: Breadcrumbs
-): OrderedBreadcrumbs {
-  const orderedFlow: OrderedFlow = sortFlow(flow);
-  const orderedBreadcrumbs: OrderedBreadcrumbs = [];
-
-  // select breadcrumbs from sorted nodes
-  let currentSectionId = "";
-  orderedFlow.forEach((node) => {
-    if (node.type == ComponentType.Section) {
-      currentSectionId = node.id;
+export function normalizeFlow(flow: Flow): NormalizedFlow {
+  let currentSectionId: string;
+  let rootNodeId: string;
+  return sortFlow(flow).map((node: IndexedNode) => {
+    const isRootNode = flow._root.edges.includes(node.id);
+    if (isRootNode) {
+      rootNodeId = node.id;
     }
 
+    const isSectionType = node.type == ComponentType.Section;
+    if (isSectionType) currentSectionId = node.id;
+
+    const normalizedNode: NormalizedNode = {
+      ...node,
+      rootNodeId,
+      sectionId: currentSectionId,
+      component: "",
+    };
+    if (node.type) {
+      normalizedNode.component = typeEnumToString(node.type!);
+    }
+    clearUndefinedKeys(normalizedNode);
+
+    return normalizedNode;
+  });
+}
+
+export function enrichBreadcrumbs(
+  flow: Flow,
+  breadcrumbs: Breadcrumbs
+): EnrichedBreadcrumbs {
+  const normalizedFlow: NormalizedFlow = normalizeFlow(flow);
+  const enrichBreadcrumbs: EnrichedBreadcrumbs = [];
+  normalizedFlow.forEach((node) => {
     const crumb: Crumb = breadcrumbs[node.id];
     if (!crumb) return;
 
+    const answerData: EnrichedCrumb["details"]["answerData"] = {};
+    crumb.answers?.forEach((id) => {
+      if (flow[id].data) answerData[id] = flow[id].data!;
+    });
+
     const enrichedCrumb: EnrichedCrumb = {
       id: node.id,
-      ...crumb,
+      answers: crumb.answers,
+      data: crumb.data,
+      override: crumb.override,
+      feedback: crumb.feedback,
+      autoAnswered: !!crumb.auto,
+      sectionId: node.sectionId,
+      details: {
+        component: node.component,
+        nodeData: node.data,
+        answerData: Object.keys(answerData).length ? answerData : undefined,
+      },
     };
-
-    // record the section id in each crumb to
-    // make section grouping and querying easy
-    if (currentSectionId) {
-      enrichedCrumb.sectionId = currentSectionId;
-    }
-
-    orderedBreadcrumbs.push(enrichedCrumb);
+    clearUndefinedKeys(enrichedCrumb);
+    enrichBreadcrumbs.push(enrichedCrumb);
   });
-  return orderedBreadcrumbs;
+  return enrichBreadcrumbs;
 }

--- a/src/mocks/complex-flow-breadcrumbs.ts
+++ b/src/mocks/complex-flow-breadcrumbs.ts
@@ -2,7 +2,8 @@ import type {
   Flow,
   OrderedFlow,
   Breadcrumbs,
-  OrderedBreadcrumbs,
+  EnrichedBreadcrumbs,
+  NormalizedFlow,
 } from "../types";
 import { ComponentType } from "../types";
 
@@ -190,6 +191,7 @@ export const flow: Flow = {
       resetButton: false,
     },
     type: ComponentType.Notice,
+    edges: ["AdjvbpObzA"],
   },
   oB2vfxQs4D: {
     data: {
@@ -222,11 +224,19 @@ export const flow: Flow = {
     type: ComponentType.Answer,
     edges: ["g0IAKsBVPQ"],
   },
+  AdjvbpObzA: {
+    data: {
+      title: "one more",
+      resetButton: false,
+    },
+    type: ComponentType.Notice,
+  },
 };
 
 export const orderedFlow: OrderedFlow = [
   {
     id: "Imks7j68BD",
+    parentId: null,
     data: {
       fn: "item",
       text: "shopping trolley",
@@ -237,6 +247,7 @@ export const orderedFlow: OrderedFlow = [
   },
   {
     id: "EqfqaqZ6CH",
+    parentId: "Imks7j68BD",
     data: {
       val: "food.fruit.apple",
       text: "apple",
@@ -245,6 +256,7 @@ export const orderedFlow: OrderedFlow = [
   },
   {
     id: "I8DznYCKVg",
+    parentId: "Imks7j68BD",
     data: {
       val: "food.fruit.banana",
       text: "banana",
@@ -253,6 +265,7 @@ export const orderedFlow: OrderedFlow = [
   },
   {
     id: "pXFKKRG6lE",
+    parentId: "Imks7j68BD",
     data: {
       val: "food.bread",
       text: "bread",
@@ -261,6 +274,7 @@ export const orderedFlow: OrderedFlow = [
   },
   {
     id: "7tV1uvR9ng",
+    parentId: "Imks7j68BD",
     data: {
       val: "tool.spanner",
       text: "spanner",
@@ -269,6 +283,7 @@ export const orderedFlow: OrderedFlow = [
   },
   {
     id: "HV0gV8DOil",
+    parentId: "Imks7j68BD",
     data: {
       fn: "item",
       text: "shopping trolley (should be skipped)",
@@ -279,15 +294,16 @@ export const orderedFlow: OrderedFlow = [
   },
   {
     id: "lTosE7Xo1j",
+    parentId: "HV0gV8DOil",
     data: {
       val: "food.fruit.apple",
       text: "apple",
     },
     type: ComponentType.Answer,
   },
-
   {
     id: "BloOMLvLJK",
+    parentId: "HV0gV8DOil",
     data: {
       val: "food.fruit.banana",
       text: "banana",
@@ -296,6 +312,7 @@ export const orderedFlow: OrderedFlow = [
   },
   {
     id: "0LzMSk4JTO",
+    parentId: "HV0gV8DOil",
     data: {
       val: "food.bread",
       text: "bread",
@@ -304,6 +321,7 @@ export const orderedFlow: OrderedFlow = [
   },
   {
     id: "OvNhSiRfdL",
+    parentId: "HV0gV8DOil",
     data: {
       val: "tool.spanner",
       text: "spanner",
@@ -312,6 +330,7 @@ export const orderedFlow: OrderedFlow = [
   },
   {
     id: "2PT6bTPTqj",
+    parentId: "HV0gV8DOil",
     data: {
       fn: "item",
       text: "contains",
@@ -321,11 +340,309 @@ export const orderedFlow: OrderedFlow = [
   },
   {
     id: "oB2vfxQs4D",
+    parentId: "2PT6bTPTqj",
     data: {
       val: "food.fruit.apple",
       text: "apples",
     },
     type: ComponentType.Answer,
+    edges: ["6RR1J1lmrM"],
+  },
+  {
+    id: "6RR1J1lmrM",
+    parentId: "oB2vfxQs4D",
+    data: {
+      color: "#EFEFEF",
+      title: "🍏",
+      resetButton: false,
+    },
+    type: ComponentType.Notice,
+  },
+  {
+    id: "ykhO0drpaY",
+    parentId: "2PT6bTPTqj",
+    data: {
+      val: "food.bread",
+      text: "bread",
+    },
+    type: ComponentType.Answer,
+    edges: ["g0IAKsBVPQ"],
+  },
+  {
+    id: "g0IAKsBVPQ",
+    parentId: "ykhO0drpaY",
+    data: {
+      color: "#EFEFEF",
+      title: "🥖",
+      resetButton: false,
+    },
+    type: ComponentType.Notice,
+  },
+  {
+    id: "U9S73zxy9n",
+    parentId: "2PT6bTPTqj",
+    data: {
+      val: "food.fruit.apple,food.bread",
+      text: "apples and bread",
+    },
+    type: ComponentType.Answer,
+    edges: ["t3SCqQKeUK"],
+  },
+  {
+    id: "t3SCqQKeUK",
+    parentId: "U9S73zxy9n",
+    data: {
+      color: "#EFEFEF",
+      title: "🍏🥖",
+      resetButton: false,
+    },
+    type: ComponentType.Notice,
+  },
+  {
+    id: "LwozLZdXCA",
+    parentId: "2PT6bTPTqj",
+    data: {
+      text: "neither apples nor bread",
+    },
+    type: ComponentType.Answer,
+    edges: ["52ZNXBMLDP"],
+  },
+  {
+    id: "52ZNXBMLDP",
+    parentId: "LwozLZdXCA",
+    data: {
+      color: "#EFEFEF",
+      title: "?, so must be a 🍌 or 🔧",
+      resetButton: false,
+    },
+    type: ComponentType.Notice,
+  },
+  {
+    id: "3H2bGdzpIN",
+    parentId: "2PT6bTPTqj",
+    data: {
+      fn: "item",
+      text: "Does the basket contain apples?",
+    },
+    type: ComponentType.Question,
+    edges: ["BJpKurp49I", "hKebzlFQDa"],
+  },
+  {
+    id: "BJpKurp49I",
+    parentId: "3H2bGdzpIN",
+    data: {
+      val: "food.fruit.apple",
+      text: "Yes",
+    },
+    type: ComponentType.Answer,
+  },
+  {
+    id: "hKebzlFQDa",
+    parentId: "3H2bGdzpIN",
+    data: {
+      text: "No",
+    },
+    type: ComponentType.Answer,
+  },
+  {
+    id: "AFX3QwbOCd",
+    parentId: "3H2bGdzpIN",
+    data: {
+      fn: "item",
+      text: "Which does the basket contain?",
+    },
+    type: ComponentType.Question,
+    edges: ["4JPWSgnGtI", "0vojjvJ6rP"],
+  },
+  {
+    id: "4JPWSgnGtI",
+    parentId: "AFX3QwbOCd",
+    data: {
+      val: "tool",
+      text: "tools",
+    },
+    type: ComponentType.Answer,
+    edges: ["KcLGMm3UWw"],
+  },
+  {
+    id: "KcLGMm3UWw",
+    parentId: "4JPWSgnGtI",
+    data: {
+      color: "#EFEFEF",
+      title: "🔧",
+      resetButton: false,
+    },
+    type: ComponentType.Notice,
+  },
+  {
+    id: "0vojjvJ6rP",
+    parentId: "AFX3QwbOCd",
+    data: {
+      val: "food",
+      text: "food",
+    },
+    type: ComponentType.Answer,
+    edges: ["mOPogpQa7V"],
+  },
+  {
+    id: "mOPogpQa7V",
+    parentId: "0vojjvJ6rP",
+    data: {
+      color: "#EFEFEF",
+      title: "🍌🍏🥖",
+      resetButton: false,
+    },
+    type: ComponentType.Notice,
+    edges: ["AdjvbpObzA"],
+  },
+  {
+    id: "AdjvbpObzA",
+    parentId: "mOPogpQa7V",
+    data: {
+      title: "one more",
+      resetButton: false,
+    },
+    type: ComponentType.Notice,
+  },
+];
+
+export const normalizedFlow: NormalizedFlow = [
+  {
+    id: "Imks7j68BD",
+    data: {
+      fn: "item",
+      text: "shopping trolley",
+      allRequired: false,
+    },
+    type: ComponentType.Checklist,
+    component: "Checklist",
+    parentId: null,
+    rootNodeId: "Imks7j68BD",
+    edges: ["EqfqaqZ6CH", "I8DznYCKVg", "pXFKKRG6lE", "7tV1uvR9ng"],
+  },
+  {
+    id: "EqfqaqZ6CH",
+    data: {
+      val: "food.fruit.apple",
+      text: "apple",
+    },
+    component: "Answer",
+    parentId: "Imks7j68BD",
+    rootNodeId: "Imks7j68BD",
+    type: ComponentType.Answer,
+  },
+  {
+    id: "I8DznYCKVg",
+    data: {
+      val: "food.fruit.banana",
+      text: "banana",
+    },
+    component: "Answer",
+    parentId: "Imks7j68BD",
+    rootNodeId: "Imks7j68BD",
+    type: ComponentType.Answer,
+  },
+  {
+    id: "pXFKKRG6lE",
+    data: {
+      val: "food.bread",
+      text: "bread",
+    },
+    component: "Answer",
+    parentId: "Imks7j68BD",
+    rootNodeId: "Imks7j68BD",
+    type: ComponentType.Answer,
+  },
+  {
+    id: "7tV1uvR9ng",
+    data: {
+      val: "tool.spanner",
+      text: "spanner",
+    },
+    component: "Answer",
+    parentId: "Imks7j68BD",
+    rootNodeId: "Imks7j68BD",
+    type: ComponentType.Answer,
+  },
+  {
+    id: "HV0gV8DOil",
+    data: {
+      fn: "item",
+      text: "shopping trolley (should be skipped)",
+      allRequired: false,
+    },
+    type: ComponentType.Checklist,
+    component: "Checklist",
+    parentId: "Imks7j68BD",
+    rootNodeId: "HV0gV8DOil",
+    edges: ["lTosE7Xo1j", "BloOMLvLJK", "0LzMSk4JTO", "OvNhSiRfdL"],
+  },
+  {
+    id: "lTosE7Xo1j",
+    data: {
+      val: "food.fruit.apple",
+      text: "apple",
+    },
+    type: ComponentType.Answer,
+    component: "Answer",
+    parentId: "HV0gV8DOil",
+    rootNodeId: "HV0gV8DOil",
+  },
+  {
+    id: "BloOMLvLJK",
+    data: {
+      val: "food.fruit.banana",
+      text: "banana",
+    },
+    type: ComponentType.Answer,
+    component: "Answer",
+    parentId: "HV0gV8DOil",
+    rootNodeId: "HV0gV8DOil",
+  },
+  {
+    id: "0LzMSk4JTO",
+    data: {
+      val: "food.bread",
+      text: "bread",
+    },
+    type: ComponentType.Answer,
+    component: "Answer",
+    parentId: "HV0gV8DOil",
+    rootNodeId: "HV0gV8DOil",
+  },
+  {
+    id: "OvNhSiRfdL",
+    data: {
+      val: "tool.spanner",
+      text: "spanner",
+    },
+    type: ComponentType.Answer,
+    component: "Answer",
+    parentId: "HV0gV8DOil",
+    rootNodeId: "HV0gV8DOil",
+  },
+  {
+    id: "2PT6bTPTqj",
+    data: {
+      fn: "item",
+      text: "contains",
+    },
+    type: ComponentType.Question,
+    component: "Question",
+    parentId: "HV0gV8DOil",
+    rootNodeId: "2PT6bTPTqj",
+    edges: ["oB2vfxQs4D", "ykhO0drpaY", "U9S73zxy9n", "LwozLZdXCA"],
+  },
+  {
+    id: "oB2vfxQs4D",
+    data: {
+      val: "food.fruit.apple",
+      text: "apples",
+    },
+    type: ComponentType.Answer,
+    component: "Answer",
+    parentId: "2PT6bTPTqj",
+    rootNodeId: "2PT6bTPTqj",
     edges: ["6RR1J1lmrM"],
   },
   {
@@ -336,6 +653,9 @@ export const orderedFlow: OrderedFlow = [
       resetButton: false,
     },
     type: ComponentType.Notice,
+    component: "Notice",
+    parentId: "oB2vfxQs4D",
+    rootNodeId: "2PT6bTPTqj",
   },
   {
     id: "ykhO0drpaY",
@@ -344,6 +664,9 @@ export const orderedFlow: OrderedFlow = [
       text: "bread",
     },
     type: ComponentType.Answer,
+    component: "Answer",
+    parentId: "2PT6bTPTqj",
+    rootNodeId: "2PT6bTPTqj",
     edges: ["g0IAKsBVPQ"],
   },
   {
@@ -354,6 +677,9 @@ export const orderedFlow: OrderedFlow = [
       resetButton: false,
     },
     type: ComponentType.Notice,
+    component: "Notice",
+    parentId: "ykhO0drpaY",
+    rootNodeId: "2PT6bTPTqj",
   },
   {
     id: "U9S73zxy9n",
@@ -362,6 +688,9 @@ export const orderedFlow: OrderedFlow = [
       text: "apples and bread",
     },
     type: ComponentType.Answer,
+    component: "Answer",
+    parentId: "2PT6bTPTqj",
+    rootNodeId: "2PT6bTPTqj",
     edges: ["t3SCqQKeUK"],
   },
   {
@@ -372,6 +701,9 @@ export const orderedFlow: OrderedFlow = [
       resetButton: false,
     },
     type: ComponentType.Notice,
+    component: "Notice",
+    parentId: "U9S73zxy9n",
+    rootNodeId: "2PT6bTPTqj",
   },
   {
     id: "LwozLZdXCA",
@@ -379,6 +711,9 @@ export const orderedFlow: OrderedFlow = [
       text: "neither apples nor bread",
     },
     type: ComponentType.Answer,
+    component: "Answer",
+    parentId: "2PT6bTPTqj",
+    rootNodeId: "2PT6bTPTqj",
     edges: ["52ZNXBMLDP"],
   },
   {
@@ -389,6 +724,9 @@ export const orderedFlow: OrderedFlow = [
       resetButton: false,
     },
     type: ComponentType.Notice,
+    component: "Notice",
+    parentId: "LwozLZdXCA",
+    rootNodeId: "2PT6bTPTqj",
   },
   {
     id: "3H2bGdzpIN",
@@ -397,6 +735,9 @@ export const orderedFlow: OrderedFlow = [
       text: "Does the basket contain apples?",
     },
     type: ComponentType.Question,
+    component: "Question",
+    parentId: "2PT6bTPTqj",
+    rootNodeId: "3H2bGdzpIN",
     edges: ["BJpKurp49I", "hKebzlFQDa"],
   },
   {
@@ -406,6 +747,9 @@ export const orderedFlow: OrderedFlow = [
       text: "Yes",
     },
     type: ComponentType.Answer,
+    component: "Answer",
+    parentId: "3H2bGdzpIN",
+    rootNodeId: "3H2bGdzpIN",
   },
   {
     id: "hKebzlFQDa",
@@ -413,6 +757,9 @@ export const orderedFlow: OrderedFlow = [
       text: "No",
     },
     type: ComponentType.Answer,
+    component: "Answer",
+    parentId: "3H2bGdzpIN",
+    rootNodeId: "3H2bGdzpIN",
   },
   {
     id: "AFX3QwbOCd",
@@ -421,6 +768,9 @@ export const orderedFlow: OrderedFlow = [
       text: "Which does the basket contain?",
     },
     type: ComponentType.Question,
+    component: "Question",
+    parentId: "3H2bGdzpIN",
+    rootNodeId: "AFX3QwbOCd",
     edges: ["4JPWSgnGtI", "0vojjvJ6rP"],
   },
   {
@@ -430,6 +780,9 @@ export const orderedFlow: OrderedFlow = [
       text: "tools",
     },
     type: ComponentType.Answer,
+    component: "Answer",
+    parentId: "AFX3QwbOCd",
+    rootNodeId: "AFX3QwbOCd",
     edges: ["KcLGMm3UWw"],
   },
   {
@@ -440,6 +793,9 @@ export const orderedFlow: OrderedFlow = [
       resetButton: false,
     },
     type: ComponentType.Notice,
+    component: "Notice",
+    parentId: "4JPWSgnGtI",
+    rootNodeId: "AFX3QwbOCd",
   },
   {
     id: "0vojjvJ6rP",
@@ -448,6 +804,9 @@ export const orderedFlow: OrderedFlow = [
       text: "food",
     },
     type: ComponentType.Answer,
+    component: "Answer",
+    parentId: "AFX3QwbOCd",
+    rootNodeId: "AFX3QwbOCd",
     edges: ["mOPogpQa7V"],
   },
   {
@@ -458,6 +817,21 @@ export const orderedFlow: OrderedFlow = [
       resetButton: false,
     },
     type: ComponentType.Notice,
+    component: "Notice",
+    parentId: "0vojjvJ6rP",
+    rootNodeId: "AFX3QwbOCd",
+    edges: ["AdjvbpObzA"],
+  },
+  {
+    id: "AdjvbpObzA",
+    data: {
+      title: "one more",
+      resetButton: false,
+    },
+    component: "Notice",
+    parentId: "mOPogpQa7V",
+    rootNodeId: "AFX3QwbOCd",
+    type: ComponentType.Notice,
   },
 ];
 
@@ -465,4 +839,4 @@ export const orderedFlow: OrderedFlow = [
 export const breadcrumbs: Breadcrumbs = {};
 
 // TODO
-export const orderedBreadcrumbs: OrderedBreadcrumbs = [];
+export const enrichedBreadcrumbs: EnrichedBreadcrumbs = [];

--- a/src/mocks/complex-flow-breadcrumbs.ts
+++ b/src/mocks/complex-flow-breadcrumbs.ts
@@ -191,7 +191,6 @@ export const flow: FlowGraph = {
       resetButton: false,
     },
     type: ComponentType.Notice,
-    edges: ["AdjvbpObzA"],
   },
   oB2vfxQs4D: {
     data: {
@@ -223,13 +222,6 @@ export const flow: FlowGraph = {
     },
     type: ComponentType.Answer,
     edges: ["g0IAKsBVPQ"],
-  },
-  AdjvbpObzA: {
-    data: {
-      title: "one more",
-      resetButton: false,
-    },
-    type: ComponentType.Notice,
   },
 };
 
@@ -490,16 +482,6 @@ export const orderedFlow: OrderedFlow = [
     data: {
       color: "#EFEFEF",
       title: "🍌🍏🥖",
-      resetButton: false,
-    },
-    type: ComponentType.Notice,
-    edges: ["AdjvbpObzA"],
-  },
-  {
-    id: "AdjvbpObzA",
-    parentId: "mOPogpQa7V",
-    data: {
-      title: "one more",
       resetButton: false,
     },
     type: ComponentType.Notice,
@@ -820,23 +802,161 @@ export const normalizedFlow: NormalizedFlow = [
     component: "Notice",
     parentId: "0vojjvJ6rP",
     rootNodeId: "AFX3QwbOCd",
-    edges: ["AdjvbpObzA"],
-  },
-  {
-    id: "AdjvbpObzA",
-    data: {
-      title: "one more",
-      resetButton: false,
-    },
-    component: "Notice",
-    parentId: "mOPogpQa7V",
-    rootNodeId: "AFX3QwbOCd",
-    type: ComponentType.Notice,
   },
 ];
 
-// TODO
-export const breadcrumbs: Breadcrumbs = {};
+export const breadcrumbs: Breadcrumbs = {
+  Imks7j68BD: {
+    auto: false,
+    answers: ["EqfqaqZ6CH", "pXFKKRG6lE"],
+  },
+  HV0gV8DOil: {
+    answers: ["lTosE7Xo1j", "0LzMSk4JTO"],
+    auto: true,
+  },
+  "2PT6bTPTqj": {
+    answers: ["U9S73zxy9n"],
+    auto: true,
+  },
+  t3SCqQKeUK: {
+    auto: false,
+  },
+  "3H2bGdzpIN": {
+    answers: ["BJpKurp49I"],
+    auto: true,
+  },
+  AFX3QwbOCd: {
+    answers: ["0vojjvJ6rP"],
+    auto: true,
+  },
+  mOPogpQa7V: {
+    auto: false,
+  },
+};
 
-// TODO
-export const enrichedBreadcrumbs: EnrichedBreadcrumbs = [];
+export const enrichedBreadcrumbs: EnrichedBreadcrumbs = [
+  {
+    id: "Imks7j68BD",
+    autoAnswered: false,
+    answers: ["EqfqaqZ6CH", "pXFKKRG6lE"],
+    details: {
+      component: "Checklist",
+      nodeData: {
+        fn: "item",
+        text: "shopping trolley",
+        allRequired: false,
+      },
+      answerData: {
+        EqfqaqZ6CH: {
+          val: "food.fruit.apple",
+          text: "apple",
+        },
+        pXFKKRG6lE: {
+          val: "food.bread",
+          text: "bread",
+        },
+      },
+    },
+  },
+  {
+    id: "HV0gV8DOil",
+    answers: ["lTosE7Xo1j", "0LzMSk4JTO"],
+    autoAnswered: true,
+    details: {
+      component: "Checklist",
+      nodeData: {
+        fn: "item",
+        text: "shopping trolley (should be skipped)",
+        allRequired: false,
+      },
+      answerData: {
+        lTosE7Xo1j: {
+          val: "food.fruit.apple",
+          text: "apple",
+        },
+        "0LzMSk4JTO": {
+          val: "food.bread",
+          text: "bread",
+        },
+      },
+    },
+  },
+  {
+    id: "2PT6bTPTqj",
+    answers: ["U9S73zxy9n"],
+    autoAnswered: true,
+    details: {
+      component: "Question",
+      nodeData: {
+        fn: "item",
+        text: "contains",
+      },
+      answerData: {
+        U9S73zxy9n: {
+          val: "food.fruit.apple,food.bread",
+          text: "apples and bread",
+        },
+      },
+    },
+  },
+  {
+    id: "t3SCqQKeUK",
+    autoAnswered: false,
+    details: {
+      component: "Notice",
+      nodeData: {
+        color: "#EFEFEF",
+        title: "🍏🥖",
+        resetButton: false,
+      },
+    },
+  },
+  {
+    id: "3H2bGdzpIN",
+    answers: ["BJpKurp49I"],
+    autoAnswered: true,
+    details: {
+      component: "Question",
+      nodeData: {
+        fn: "item",
+        text: "Does the basket contain apples?",
+      },
+      answerData: {
+        BJpKurp49I: {
+          val: "food.fruit.apple",
+          text: "Yes",
+        },
+      },
+    },
+  },
+  {
+    id: "AFX3QwbOCd",
+    answers: ["0vojjvJ6rP"],
+    autoAnswered: true,
+    details: {
+      component: "Question",
+      answerData: {
+        "0vojjvJ6rP": {
+          val: "food",
+          text: "food",
+        },
+      },
+      nodeData: {
+        fn: "item",
+        text: "Which does the basket contain?",
+      },
+    },
+  },
+  {
+    id: "mOPogpQa7V",
+    autoAnswered: false,
+    details: {
+      component: "Notice",
+      nodeData: {
+        color: "#EFEFEF",
+        title: "🍌🍏🥖",
+        resetButton: false,
+      },
+    },
+  },
+];

--- a/src/mocks/complex-flow-breadcrumbs.ts
+++ b/src/mocks/complex-flow-breadcrumbs.ts
@@ -1,5 +1,5 @@
 import type {
-  Flow,
+  FlowGraph,
   OrderedFlow,
   Breadcrumbs,
   EnrichedBreadcrumbs,
@@ -7,7 +7,7 @@ import type {
 } from "../types";
 import { ComponentType } from "../types";
 
-export const flow: Flow = {
+export const flow: FlowGraph = {
   _root: {
     edges: [
       "Imks7j68BD",

--- a/src/mocks/section-flow-breadcrumbs.ts
+++ b/src/mocks/section-flow-breadcrumbs.ts
@@ -1,5 +1,5 @@
 import type {
-  Flow,
+  FlowGraph,
   OrderedFlow,
   Breadcrumbs,
   EnrichedBreadcrumbs,
@@ -7,7 +7,7 @@ import type {
 } from "../types";
 import { ComponentType } from "../types";
 
-export const flow: Flow = {
+export const flow: FlowGraph = {
   _root: {
     edges: [
       "firstSection",

--- a/src/mocks/section-flow-breadcrumbs.ts
+++ b/src/mocks/section-flow-breadcrumbs.ts
@@ -2,7 +2,8 @@ import type {
   Flow,
   OrderedFlow,
   Breadcrumbs,
-  OrderedBreadcrumbs,
+  EnrichedBreadcrumbs,
+  NormalizedFlow,
 } from "../types";
 import { ComponentType } from "../types";
 
@@ -79,6 +80,7 @@ export const flow: Flow = {
 export const orderedFlow: OrderedFlow = [
   {
     id: "firstSection",
+    parentId: null,
     data: {
       title: "First Section",
     },
@@ -86,6 +88,7 @@ export const orderedFlow: OrderedFlow = [
   },
   {
     id: "firstQuestion",
+    parentId: "firstSection",
     data: {
       text: "First Question",
     },
@@ -94,6 +97,7 @@ export const orderedFlow: OrderedFlow = [
   },
   {
     id: "firstAnswer",
+    parentId: "firstQuestion",
     data: {
       text: "Answer 1",
     },
@@ -101,6 +105,7 @@ export const orderedFlow: OrderedFlow = [
   },
   {
     id: "secondSection",
+    parentId: "firstQuestion",
     data: {
       title: "Second Section",
     },
@@ -108,6 +113,7 @@ export const orderedFlow: OrderedFlow = [
   },
   {
     id: "secondQuestion",
+    parentId: "secondSection",
     data: {
       text: "Second Question",
     },
@@ -116,6 +122,7 @@ export const orderedFlow: OrderedFlow = [
   },
   {
     id: "secondAnswer",
+    parentId: "secondQuestion",
     data: {
       text: "Answer 2",
     },
@@ -123,6 +130,7 @@ export const orderedFlow: OrderedFlow = [
   },
   {
     id: "thirdSection",
+    parentId: "secondQuestion",
     data: {
       title: "Third Section",
     },
@@ -130,6 +138,7 @@ export const orderedFlow: OrderedFlow = [
   },
   {
     id: "thirdQuestion",
+    parentId: "thirdSection",
     data: {
       text: "Third Question",
     },
@@ -138,6 +147,112 @@ export const orderedFlow: OrderedFlow = [
   },
   {
     id: "thirdAnswer",
+    parentId: "thirdQuestion",
+    data: {
+      text: "Answer 3",
+    },
+    type: ComponentType.Answer,
+  },
+];
+
+export const normalizedFlow: NormalizedFlow = [
+  {
+    id: "firstSection",
+    component: "Section",
+    sectionId: "firstSection",
+    rootNodeId: "firstSection",
+    parentId: null,
+    data: {
+      title: "First Section",
+    },
+    type: ComponentType.Section,
+  },
+  {
+    id: "firstQuestion",
+    component: "Question",
+    sectionId: "firstSection",
+    rootNodeId: "firstQuestion",
+    parentId: "firstSection",
+    data: {
+      text: "First Question",
+    },
+    type: ComponentType.Question,
+    edges: ["firstAnswer"],
+  },
+  {
+    id: "firstAnswer",
+    component: "Answer",
+    sectionId: "firstSection",
+    rootNodeId: "firstQuestion",
+    parentId: "firstQuestion",
+    data: {
+      text: "Answer 1",
+    },
+    type: ComponentType.Answer,
+  },
+  {
+    id: "secondSection",
+    component: "Section",
+    sectionId: "secondSection",
+    rootNodeId: "secondSection",
+    parentId: "firstQuestion",
+    data: {
+      title: "Second Section",
+    },
+    type: ComponentType.Section,
+  },
+  {
+    id: "secondQuestion",
+    component: "Question",
+    sectionId: "secondSection",
+    rootNodeId: "secondQuestion",
+    parentId: "secondSection",
+    data: {
+      text: "Second Question",
+    },
+    type: ComponentType.Question,
+    edges: ["secondAnswer"],
+  },
+  {
+    id: "secondAnswer",
+    component: "Answer",
+    sectionId: "secondSection",
+    rootNodeId: "secondQuestion",
+    parentId: "secondQuestion",
+    data: {
+      text: "Answer 2",
+    },
+    type: ComponentType.Answer,
+  },
+  {
+    id: "thirdSection",
+    component: "Section",
+    sectionId: "thirdSection",
+    rootNodeId: "thirdSection",
+    parentId: "secondQuestion",
+    data: {
+      title: "Third Section",
+    },
+    type: ComponentType.Section,
+  },
+  {
+    id: "thirdQuestion",
+    component: "Question",
+    sectionId: "thirdSection",
+    rootNodeId: "thirdQuestion",
+    parentId: "thirdSection",
+    data: {
+      text: "Third Question",
+    },
+    type: ComponentType.Question,
+    edges: ["thirdAnswer"],
+  },
+  {
+    id: "thirdAnswer",
+    component: "Answer",
+    sectionId: "thirdSection",
+    rootNodeId: "thirdQuestion",
+    parentId: "thirdQuestion",
     data: {
       text: "Answer 3",
     },
@@ -169,38 +284,89 @@ export const breadcrumbs: Breadcrumbs = {
   },
 };
 
-export const orderedBreadcrumbs: OrderedBreadcrumbs = [
+export const enrichedBreadcrumbs: EnrichedBreadcrumbs = [
   {
     id: "firstSection",
     sectionId: "firstSection",
-    auto: false,
+    autoAnswered: false,
+    details: {
+      component: "Section",
+      nodeData: {
+        title: "First Section",
+      },
+    },
   },
   {
     id: "firstQuestion",
     sectionId: "firstSection",
-    auto: false,
+    autoAnswered: false,
     answers: ["firstAnswer"],
+    details: {
+      component: "Question",
+      nodeData: {
+        text: "First Question",
+      },
+      answerData: {
+        firstAnswer: {
+          text: "Answer 1",
+        },
+      },
+    },
   },
   {
     id: "secondSection",
     sectionId: "secondSection",
-    auto: false,
+    autoAnswered: false,
+    details: {
+      component: "Section",
+      nodeData: {
+        title: "Second Section",
+      },
+    },
   },
   {
     id: "secondQuestion",
     sectionId: "secondSection",
-    auto: false,
+    autoAnswered: false,
     answers: ["secondAnswer"],
+    details: {
+      component: "Question",
+      nodeData: {
+        text: "Second Question",
+      },
+      answerData: {
+        secondAnswer: {
+          text: "Answer 2",
+        },
+      },
+    },
   },
   {
     id: "thirdSection",
     sectionId: "thirdSection",
-    auto: false,
+    autoAnswered: false,
+    details: {
+      component: "Section",
+      nodeData: {
+        title: "Third Section",
+      },
+    },
   },
   {
     id: "thirdQuestion",
     sectionId: "thirdSection",
-    auto: false,
+    autoAnswered: false,
     answers: ["thirdAnswer"],
+    details: {
+      component: "Question",
+      nodeData: {
+        text: "Third Question",
+      },
+      answerData: {
+        thirdAnswer: {
+          text: "Answer 3",
+        },
+      },
+    },
   },
 ];

--- a/src/mocks/simple-flow-breadcrumbs.ts
+++ b/src/mocks/simple-flow-breadcrumbs.ts
@@ -2,7 +2,8 @@ import type {
   Flow,
   OrderedFlow,
   Breadcrumbs,
-  OrderedBreadcrumbs,
+  EnrichedBreadcrumbs,
+  NormalizedFlow,
 } from "../types";
 import { ComponentType } from "../types";
 
@@ -54,6 +55,7 @@ export const flow: Flow = {
 export const orderedFlow: OrderedFlow = [
   {
     id: "firstQuestion",
+    parentId: null,
     data: {
       text: "First Question",
     },
@@ -62,6 +64,7 @@ export const orderedFlow: OrderedFlow = [
   },
   {
     id: "firstAnswer",
+    parentId: "firstQuestion",
     data: {
       text: "Answer 1",
     },
@@ -69,6 +72,7 @@ export const orderedFlow: OrderedFlow = [
   },
   {
     id: "secondQuestion",
+    parentId: "firstQuestion",
     data: {
       text: "Second Question",
     },
@@ -77,6 +81,7 @@ export const orderedFlow: OrderedFlow = [
   },
   {
     id: "secondAnswer",
+    parentId: "secondQuestion",
     data: {
       text: "Answer 2",
     },
@@ -84,6 +89,7 @@ export const orderedFlow: OrderedFlow = [
   },
   {
     id: "thirdQuestion",
+    parentId: "secondQuestion",
     data: {
       text: "Third Question",
     },
@@ -92,6 +98,73 @@ export const orderedFlow: OrderedFlow = [
   },
   {
     id: "thirdAnswer",
+    parentId: "thirdQuestion",
+    data: {
+      text: "Answer 3",
+    },
+    type: ComponentType.Answer,
+  },
+];
+
+export const normalizedFlow: NormalizedFlow = [
+  {
+    id: "firstQuestion",
+    component: "Question",
+    parentId: null,
+    rootNodeId: "firstQuestion",
+    data: {
+      text: "First Question",
+    },
+    type: ComponentType.Question,
+    edges: ["firstAnswer"],
+  },
+  {
+    id: "firstAnswer",
+    component: "Answer",
+    parentId: "firstQuestion",
+    rootNodeId: "firstQuestion",
+    data: {
+      text: "Answer 1",
+    },
+    type: ComponentType.Answer,
+  },
+  {
+    id: "secondQuestion",
+    component: "Question",
+    parentId: "firstQuestion",
+    rootNodeId: "secondQuestion",
+    data: {
+      text: "Second Question",
+    },
+    type: ComponentType.Question,
+    edges: ["secondAnswer"],
+  },
+  {
+    id: "secondAnswer",
+    component: "Answer",
+    parentId: "secondQuestion",
+    rootNodeId: "secondQuestion",
+    data: {
+      text: "Answer 2",
+    },
+    type: ComponentType.Answer,
+  },
+  {
+    id: "thirdQuestion",
+    component: "Question",
+    parentId: "secondQuestion",
+    rootNodeId: "thirdQuestion",
+    data: {
+      text: "Third Question",
+    },
+    type: ComponentType.Question,
+    edges: ["thirdAnswer"],
+  },
+  {
+    id: "thirdAnswer",
+    component: "Answer",
+    parentId: "thirdQuestion",
+    rootNodeId: "thirdQuestion",
     data: {
       text: "Answer 3",
     },
@@ -114,20 +187,53 @@ export const breadcrumbs: Breadcrumbs = {
   },
 };
 
-export const orderedBreadcrumbs: OrderedBreadcrumbs = [
+export const enrichedBreadcrumbs: EnrichedBreadcrumbs = [
   {
     id: "firstQuestion",
-    auto: false,
+    autoAnswered: false,
     answers: ["firstAnswer"],
+    details: {
+      component: "Question",
+      nodeData: {
+        text: "First Question",
+      },
+      answerData: {
+        firstAnswer: {
+          text: "Answer 1",
+        },
+      },
+    },
   },
   {
     id: "secondQuestion",
-    auto: false,
+    autoAnswered: false,
     answers: ["secondAnswer"],
+    details: {
+      component: "Question",
+      nodeData: {
+        text: "Second Question",
+      },
+      answerData: {
+        secondAnswer: {
+          text: "Answer 2",
+        },
+      },
+    },
   },
   {
     id: "thirdQuestion",
-    auto: false,
+    autoAnswered: false,
     answers: ["thirdAnswer"],
+    details: {
+      component: "Question",
+      nodeData: {
+        text: "Third Question",
+      },
+      answerData: {
+        thirdAnswer: {
+          text: "Answer 3",
+        },
+      },
+    },
   },
 ];

--- a/src/mocks/simple-flow-breadcrumbs.ts
+++ b/src/mocks/simple-flow-breadcrumbs.ts
@@ -1,5 +1,5 @@
 import type {
-  Flow,
+  FlowGraph,
   OrderedFlow,
   Breadcrumbs,
   EnrichedBreadcrumbs,
@@ -7,7 +7,7 @@ import type {
 } from "../types";
 import { ComponentType } from "../types";
 
-export const flow: Flow = {
+export const flow: FlowGraph = {
   _root: {
     edges: ["firstQuestion", "secondQuestion", "thirdQuestion"],
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,7 +51,7 @@ export interface Node {
   data?: Record<NodeId, Value>;
 }
 
-export type Flow = {
+export type FlowGraph = {
   _root: {
     edges: Edges;
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,13 +32,23 @@ export enum ComponentType {
   Confirmation = 725,
 }
 
-export type Edges = Array<string>;
+export type NodeId = string;
+
+export type Edges = Array<NodeId>;
+
+export type Value =
+  | string
+  | number
+  | boolean
+  | null
+  | Array<Value>
+  | { [key: string]: Value };
 
 export interface Node {
   id?: string;
-  type?: number;
+  type?: ComponentType;
   edges?: Edges;
-  data?: Record<string, any>;
+  data?: Record<NodeId, Value>;
 }
 
 export type Flow = {
@@ -50,25 +60,42 @@ export type Flow = {
 
 export interface IndexedNode extends Node {
   id: string;
+  parentId: string | null; // null if it is the first node
 }
 
 export type OrderedFlow = Array<IndexedNode>;
 
-export interface Crumb {
-  answers?: Array<string>;
-  data?: Record<string, any>;
-  auto?: boolean;
-  override?: Record<string, any>;
-  feedback?: string;
+export interface NormalizedNode extends IndexedNode {
+  component: string;
+  sectionId?: string;
+  rootNodeId: string;
 }
 
-export interface EnrichedCrumb extends Crumb {
-  id: string;
-  sectionId?: string;
+export type NormalizedFlow = Array<NormalizedNode>;
+
+export interface Crumb {
+  auto?: boolean;
+  answers?: Array<string>;
+  data?: Record<string, Value>;
+  override?: Record<string, Value>;
+  feedback?: string;
 }
 
 export type Breadcrumbs = {
   [key: string]: Crumb;
 };
 
-export type OrderedBreadcrumbs = Array<EnrichedCrumb>;
+export interface EnrichedCrumb extends Crumb {
+  id: string;
+  autoAnswered: boolean;
+  sectionId?: string;
+  details: {
+    component: string;
+    nodeData?: Record<string, Value>;
+    answerData?: {
+      [id: NodeId]: Record<string, Value>;
+    };
+  };
+}
+
+export type EnrichedBreadcrumbs = Array<EnrichedCrumb>;

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["es2021"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noImplicitAny": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2021",
+    "rootDir": "./src",
+    "typeRoots": ["./node_modules/@types", "./@types"],
+    "noEmit": true
+  },
+  "include": [
+    "src"
+  ]
+}


### PR DESCRIPTION
This PR adds the groundwork for a rich set of logic queries using normalized data structures.

By turning the graph into an ordered array with a rich set of data in each node, querying the flow becomes quite straightforward. `NormalizedFlow` adds enough data to each node to enable forward and backward traversal and other query functions (i.e sections). Although this data structure could be quite large for very big flows, the operations should be fairly inexpensive and fast with a structure like this.

This also starts to move the data structures towards nicer serialization (e.g. component type has a string name and a helper lookup function).

There are a lot of test data changes here - the meat of the change is visible in the [type declarations ](https://github.com/theopensystemslab/planx-core/pull/4/files#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410a).