### PR TITLE
feat: GetTemplates for flow and session

### DIFF
--- a/src/document-templates.ts
+++ b/src/document-templates.ts
@@ -1,21 +1,38 @@
 import { gql } from "graphql-request";
 import type { GraphQLClient } from "graphql-request";
 
-export async function getDocumentTemplateNames(
+export async function getDocumentTemplateNamesForFlow(
   client: GraphQLClient,
   flowId: string
 ): Promise<string[]> {
-  const { flow_document_templates: response } = await client.request(
-    gql`
-      query GetDocumentTemplateNames($flowId: uuid!) {
-        flow_document_templates(where: {flow: {_eq: $flowId}}) {
-          document_template
-        }
+  const { flow_document_templates: response } = await client.request(gql`
+    query GetDocumentTemplateNamesForFlow($flowId: uuid!) {
+      flow_document_templates(where: {flow: {_eq: $flowId}}) {
+        document_template
       }
-    `,
+    }`,
     { flowId }
   );
   return response.map(
     (data: { document_template: string }) => data.document_template
   );
+}
+
+export async function getDocumentTemplateNamesForSession(
+  client: GraphQLClient,
+  sessionId: string
+): Promise<string[]> {
+  const { lowcal_sessions_by_pk: { flow: { document_templates }} } = await client.request(gql`
+    query GetDocumentTemplateNamesForSession($sessionId: uuid!) {
+      lowcal_sessions_by_pk(id: $sessionId) {
+        flow {
+          document_templates {
+            document_template
+          }
+        }
+      }
+    }`,
+    { sessionId }
+  );
+  return document_templates.map((data: Record<"document_template", string>) => data.document_template)
 }

--- a/src/export/oneApp/index.ts
+++ b/src/export/oneApp/index.ts
@@ -1,12 +1,12 @@
 import { GraphQLClient } from 'graphql-request';
 import { OneAppPayload } from "./model";
-import { getDocumentTemplateNames } from "../../document-templates"
+import { getDocumentTemplateNamesForSession } from "../../document-templates"
 import { getSessionById } from '../../session';
 import { Passport } from '../../passport';
 
 export async function generateOneAppXML(client: GraphQLClient, sessionId: string): Promise<string> {
   const session = await getSessionById(client, sessionId);
-  const templateNames = await getDocumentTemplateNames(client, session.flowId);
+  const templateNames = await getDocumentTemplateNamesForSession(client, sessionId);
   const payload = new OneAppPayload({
     sessionId: session.id,
     passport: session.data.passport,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,9 @@ import { createUser } from "./user";
 import { createTeam } from "./team";
 import { createFlow, publishFlow } from "./flow";
 import type { GraphQLClient } from "graphql-request";
-import { getDocumentTemplateNames } from "./document-templates";
 import { generateOneAppXML } from "./export/oneApp";
 import { getSessionById } from "./session";
+import { getDocumentTemplateNamesForFlow, getDocumentTemplateNamesForSession } from "./document-templates";
 import { Session } from "./types";
 
 const defaultURL = process.env.HASURA_GRAPHQL_URL;
@@ -75,8 +75,17 @@ export class CoreDomainClient {
     return publishFlow(this.client, args);
   }
 
+  // TODO: Remove this once planx-new updated
   async getDocumentTemplateNames(flowId: string): Promise<string[]> {
-    return getDocumentTemplateNames(this.client, flowId);
+    return getDocumentTemplateNamesForFlow(this.client, flowId);
+  }
+
+  async getDocumentTemplateNamesForFlow(flowId: string): Promise<string[]> {
+    return getDocumentTemplateNamesForFlow(this.client, flowId);
+  }
+
+  async getDocumentTemplateNamesForSession(sessionId: string): Promise<string[]> {
+    return getDocumentTemplateNamesForSession(this.client, sessionId);
   }
 
   async generateOneAppXML(sessionId: string): Promise<string> {


### PR DESCRIPTION
When handling templates, we currently derive everything from a `sessionId`. A new function has been added to allow us to fetch template names from a `sessionId`.

Relies on db changes made in https://github.com/theopensystemslab/planx-new/pull/1553