### PR TITLE
fix: `GetSessionById` query syntax

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -11,7 +11,7 @@ export async function getSessionById(client: GraphQLClient, sessionId: string): 
           id: $id
         ) {
           data
-          flow_id: flowId
+          flowId: flow_id
           id
         }
       }


### PR DESCRIPTION
A submission to Uniform via staging failed with the following error - 

```{
    "data": {
        "message": "{\"error\":\"Failed to send to Uniform. Error: Failed to generate OneApp XML. Error - Error: field \\\"flowId\\\" not found in type: 'lowcal_sessions': {\\\"response\\\":{\\\"errors\\\":[{\\\"extensions\\\":{\\\"path\\\":\\\"$.selectionSet.lowcal_sessions_by_pk.selectionSet.flowId\\\",\\\"code\\\":\\\"validation-failed\\\"},\\\"message\\\":\\\"field \\\\\\\"flowId\\\\\\\" not found in type: 'lowcal_sessions'\\\"}],\\\"status\\\":200,\\\"headers\\\":{}},\\\"request\\\":{\\\"query\\\":\\\"\\\\n      query GetSessionById(\\\\n        $id: uuid!\\\\n      ) {\\\\n        lowcal_sessions_by_pk(\\\\n          id: $id\\\\n        ) {\\\\n          data\\\\n          flow_id: flowId\\\\n          id\\\\n        }\\\\n      }\\\\n    \\\",\\\"variables\\\":{\\\"id\\\":\\\"8449dd8e-47b2-4ab8-9cdb-87e89f5d2155\\\"}}}\"}"
    },
    "version": "1",
    "type": "client_error"
}
```

This wasn't caught on submission by Airbrake, so I'll double check how that's being handled next.