### PR TITLE
feat: Add optional `sectionId` to sorted flow nodes

### DIFF
--- a/src/logic.test.ts
+++ b/src/logic.test.ts
@@ -136,6 +136,7 @@ describe("findNextNodeOfType", () => {
     expect(nextNoticeNode).toEqual({
       id: "NoticeB",
       parentId: "ChecklistOptionB", // this isn't really the parent but the previous node
+      sectionId: "Section2",
       data: { color: "#EFEFEF", title: "Reached B", resetButton: false },
       type: ComponentType.Notice,
     });
@@ -147,6 +148,7 @@ describe("findNextNodeOfType", () => {
     expect(nextSectionNode).toEqual({
       id: "Section3",
       parentId: "EndOfSection2Notice",
+      sectionId: "Section3",
       data: { title: "Section Three" },
       type: ComponentType.Section,
     });

--- a/src/logic.ts
+++ b/src/logic.ts
@@ -10,6 +10,7 @@ import type {
 } from "./types";
 
 export function sortFlow(flow: FlowGraph): OrderedFlow {
+  let sectionId: string | undefined;
   const nodes: IndexedNode[] = [];
   const searchNodeEdges = (id: string, parentId?: string) => {
     const foundNode = flow[id];
@@ -19,9 +20,11 @@ export function sortFlow(flow: FlowGraph): OrderedFlow {
     if (!foundNode.type) {
       throw new Error(`Node is missing a type: "${JSON.stringify(foundNode)}"`);
     }
+    sectionId = foundNode.type == ComponentType.Section ? id : sectionId;
     nodes.push({
       id,
       parentId: parentId || null,
+      sectionId,
       type: foundNode.type!,
       edges: foundNode.edges,
       data: foundNode.data,

--- a/src/mocks/section-flow-breadcrumbs.ts
+++ b/src/mocks/section-flow-breadcrumbs.ts
@@ -81,6 +81,7 @@ export const orderedFlow: OrderedFlow = [
   {
     id: "firstSection",
     parentId: null,
+    sectionId: "firstSection",
     data: {
       title: "First Section",
     },
@@ -89,6 +90,7 @@ export const orderedFlow: OrderedFlow = [
   {
     id: "firstQuestion",
     parentId: "firstSection",
+    sectionId: "firstSection",
     data: {
       text: "First Question",
     },
@@ -98,6 +100,7 @@ export const orderedFlow: OrderedFlow = [
   {
     id: "firstAnswer",
     parentId: "firstQuestion",
+    sectionId: "firstSection",
     data: {
       text: "Answer 1",
     },
@@ -106,6 +109,7 @@ export const orderedFlow: OrderedFlow = [
   {
     id: "secondSection",
     parentId: "firstQuestion",
+    sectionId: "secondSection",
     data: {
       title: "Second Section",
     },
@@ -114,6 +118,7 @@ export const orderedFlow: OrderedFlow = [
   {
     id: "secondQuestion",
     parentId: "secondSection",
+    sectionId: "secondSection",
     data: {
       text: "Second Question",
     },
@@ -123,6 +128,7 @@ export const orderedFlow: OrderedFlow = [
   {
     id: "secondAnswer",
     parentId: "secondQuestion",
+    sectionId: "secondSection",
     data: {
       text: "Answer 2",
     },
@@ -131,6 +137,7 @@ export const orderedFlow: OrderedFlow = [
   {
     id: "thirdSection",
     parentId: "secondQuestion",
+    sectionId: "thirdSection",
     data: {
       title: "Third Section",
     },
@@ -139,6 +146,7 @@ export const orderedFlow: OrderedFlow = [
   {
     id: "thirdQuestion",
     parentId: "thirdSection",
+    sectionId: "thirdSection",
     data: {
       text: "Third Question",
     },
@@ -148,6 +156,7 @@ export const orderedFlow: OrderedFlow = [
   {
     id: "thirdAnswer",
     parentId: "thirdQuestion",
+    sectionId: "thirdSection",
     data: {
       text: "Answer 3",
     },

--- a/src/types/flow.ts
+++ b/src/types/flow.ts
@@ -23,6 +23,7 @@ export type IndexedNode = Node & {
   id: string;
   type: ComponentType;
   parentId: string | null; // null if it is the first node
+  sectionId?: string;
 };
 
 export type OrderedFlow = Array<IndexedNode>;


### PR DESCRIPTION
When sorting a flow, it seems useful to track which node belongs to which section. This PR adds an optional `sectionId` field to each node in a sorted flow.