### PR TITLE
feat: add payment amount to payment requests

### DIFF
--- a/src/flow.ts
+++ b/src/flow.ts
@@ -8,7 +8,7 @@ export async function getLatestFlowGraph(
 ): Promise<FlowGraph | undefined> {
   const { published_flows: response } = await client.request(
     gql`
-      query GetPublishedFlowData($flowId: uuid!) {
+      query GetLatestPublishedFlowData($flowId: uuid!) {
         published_flows(
           where: { flow_id: { _eq: $flowId } }
           order_by: { created_at: desc }
@@ -20,7 +20,7 @@ export async function getLatestFlowGraph(
     `,
     { flowId }
   );
-  return response.published_flows.length ? response.published_flows[0] : null;
+  return response?.length ? response[0] : null;
 }
 
 export async function createFlow(

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -1,5 +1,27 @@
 import { gql } from "graphql-request";
 import type { GraphQLClient } from "graphql-request";
+import type { FlowGraph } from "./types";
+
+export async function getLatestFlowGraph(
+  client: GraphQLClient,
+  flowId: string
+): Promise<FlowGraph | undefined> {
+  const { published_flows: response } = await client.request(
+    gql`
+      query GetPublishedFlowData($flowId: uuid!) {
+        published_flows(
+          where: { flow_id: { _eq: $flowId } }
+          order_by: { created_at: desc }
+          limit: 1
+        ) {
+          data
+        }
+      }
+    `,
+    { flowId }
+  );
+  return response.published_flows.length ? response.published_flows[0] : null;
+}
 
 export async function createFlow(
   client: GraphQLClient,

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -20,7 +20,7 @@ export async function getLatestFlowGraph(
     `,
     { flowId }
   );
-  return response?.length ? response[0] : null;
+  return response?.length ? response[0].data : null;
 }
 
 export async function createFlow(

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -5,7 +5,7 @@ import type { FlowGraph } from "./types";
 export async function getLatestFlowGraph(
   client: GraphQLClient,
   flowId: string
-): Promise<FlowGraph | undefined> {
+): Promise<FlowGraph | null> {
   const { published_flows: response } = await client.request(
     gql`
       query GetLatestPublishedFlowData($flowId: uuid!) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,6 +118,7 @@ export class CoreDomainClient {
 
   async createPaymentRequest(args: {
     sessionId: string;
+    applicantName: string;
     payeeName: string;
     payeeEmail: string;
     sessionPreviewKeys: Array<KeyPath>;

--- a/src/payment-request.test.ts
+++ b/src/payment-request.test.ts
@@ -1,7 +1,7 @@
-import { buildSessionPreviewData } from "./payment-request";
+import { validateSessionData } from "./payment-request";
 import type { Session, KeyPath } from "./types";
 
-describe("buildSessionPreviewData", () => {
+describe("validateSessionData", () => {
   test("passport data must be available", () => {
     const emptySession: Session = {
       id: "abc",
@@ -13,9 +13,105 @@ describe("buildSessionPreviewData", () => {
       },
     };
     const previewKeys: KeyPath[] = [];
-    expect(() => buildSessionPreviewData(emptySession, previewKeys)).toThrow(
-      "passport data not found"
-    );
+    const amountKey = "amount";
+    expect(() =>
+      validateSessionData({
+        session: emptySession,
+        sessionPreviewKeys: previewKeys,
+        amountKey,
+      })
+    ).toThrow("passport data not found");
+  });
+  test("amount must not be undefined", () => {
+    const invalidSession: Session = {
+      id: "abc",
+      flowId: "abc",
+      data: {
+        id: "abc",
+        passport: {
+          data: {},
+        },
+        breadcrumbs: {},
+      },
+    };
+    const previewKeys: KeyPath[] = [];
+    const amountKey = "amount";
+    expect(() =>
+      validateSessionData({
+        session: invalidSession,
+        sessionPreviewKeys: previewKeys,
+        amountKey,
+      })
+    ).toThrow('invalid amount "undefined"');
+  });
+  test("amount must be greater than zero", () => {
+    const invalidSession: Session = {
+      id: "abc",
+      flowId: "abc",
+      data: {
+        id: "abc",
+        passport: {
+          data: {
+            amount: -2,
+          },
+        },
+        breadcrumbs: {},
+      },
+    };
+    const previewKeys: KeyPath[] = [];
+    const amountKey = "amount";
+    expect(() =>
+      validateSessionData({
+        session: invalidSession,
+        sessionPreviewKeys: previewKeys,
+        amountKey,
+      })
+    ).toThrow('invalid amount "-2"');
+    const invalidSession2: Session = {
+      id: "abc",
+      flowId: "abc",
+      data: {
+        id: "abc",
+        passport: {
+          data: {
+            amount: 0,
+          },
+        },
+        breadcrumbs: {},
+      },
+    };
+    expect(() =>
+      validateSessionData({
+        session: invalidSession2,
+        sessionPreviewKeys: previewKeys,
+        amountKey,
+      })
+    ).toThrow('invalid amount "0"');
+  });
+  test("keys must be present in the passport", () => {
+    const invalidSession: Session = {
+      id: "abc",
+      flowId: "abc",
+      data: {
+        id: "abc",
+        passport: {
+          data: {
+            key1: "a",
+            amount: 2,
+          },
+        },
+        breadcrumbs: {},
+      },
+    };
+    const previewKeys: KeyPath[] = [["key1"], ["key2", "notFoundKey"]];
+    const amountKey = "amount";
+    expect(() =>
+      validateSessionData({
+        session: invalidSession,
+        sessionPreviewKeys: previewKeys,
+        amountKey,
+      })
+    ).toThrow('passport key "key2.notFoundKey" not found in passport data');
   });
   test("a simple set of session preview keys are extracted from the session", () => {
     const session: Session = {
@@ -28,6 +124,7 @@ describe("buildSessionPreviewData", () => {
             a: 1,
             b: 2,
             c: 3,
+            amount: 5,
           },
         },
         breadcrumbs: {},
@@ -35,8 +132,15 @@ describe("buildSessionPreviewData", () => {
     };
     const previewKeys: KeyPath[] = [["a"], ["b"], ["c"]];
 
-    const sessionPreviewData = buildSessionPreviewData(session, previewKeys);
-    expect(sessionPreviewData).toEqual({ a: 1, b: 2, c: 3 });
+    const validatedSessionData = validateSessionData({
+      session: session,
+      sessionPreviewKeys: previewKeys,
+      amountKey: "amount",
+    });
+    expect(validatedSessionData).toEqual({
+      amount: 5,
+      sessionPreviewData: { a: 1, b: 2, c: 3 },
+    });
   });
   test("a set of compound keys are extracted from the session", () => {
     const session: Session = {
@@ -49,14 +153,22 @@ describe("buildSessionPreviewData", () => {
             "a.b": 1,
             "c.d": 2,
             "c.d.e": 3,
+            "payment.amount": 7,
           },
         },
         breadcrumbs: {},
       },
     };
     const previewKeys: KeyPath[] = [["a.b"], ["c.d"], ["c.d.e"]];
-    const sessionPreviewData = buildSessionPreviewData(session, previewKeys);
-    expect(sessionPreviewData).toEqual({ "a.b": 1, "c.d": 2, "c.d.e": 3 });
+    const validatedSessionData = validateSessionData({
+      session: session,
+      sessionPreviewKeys: previewKeys,
+      amountKey: "payment.amount",
+    });
+    expect(validatedSessionData).toEqual({
+      amount: 7,
+      sessionPreviewData: { "a.b": 1, "c.d": 2, "c.d.e": 3 },
+    });
   });
   test("a set of nested and compound keys are extracted from the session", () => {
     const session: Session = {
@@ -74,6 +186,7 @@ describe("buildSessionPreviewData", () => {
             b: {
               "c.d.e.f": false,
             },
+            "payment.amount": 7,
           },
         },
         breadcrumbs: {},
@@ -85,14 +198,21 @@ describe("buildSessionPreviewData", () => {
       ["a", "c.d.e"],
       ["b", "c.d.e.f"],
     ];
-    const sessionPreviewData = buildSessionPreviewData(session, previewKeys);
-    expect(sessionPreviewData).toEqual({
-      a: {
-        c: 0,
-        "c.d": true,
-        "c.d.e": 5,
+    const validatedSessionData = validateSessionData({
+      session: session,
+      sessionPreviewKeys: previewKeys,
+      amountKey: "payment.amount",
+    });
+    expect(validatedSessionData).toEqual({
+      amount: 7,
+      sessionPreviewData: {
+        a: {
+          c: 0,
+          "c.d": true,
+          "c.d.e": 5,
+        },
+        b: { "c.d.e.f": false },
       },
-      b: { "c.d.e.f": false },
     });
   });
 });

--- a/src/payment-request.test.ts
+++ b/src/payment-request.test.ts
@@ -1,7 +1,7 @@
-import { validateSessionData } from "./payment-request";
+import { extractSessionPreviewData } from "./payment-request";
 import type { Session, KeyPath } from "./types";
 
-describe("validateSessionData", () => {
+describe("extractSessionPreviewData", () => {
   test("passport data must be available", () => {
     const emptySession: Session = {
       id: "abc",
@@ -13,80 +13,9 @@ describe("validateSessionData", () => {
       },
     };
     const previewKeys: KeyPath[] = [];
-    const paymentAmountKey = "amount";
-    expect(() =>
-      validateSessionData({
-        session: emptySession,
-        sessionPreviewKeys: previewKeys,
-        paymentAmountKey,
-      })
-    ).toThrow("passport data not found");
-  });
-  test("amount must not be undefined", () => {
-    const invalidSession: Session = {
-      id: "abc",
-      flowId: "abc",
-      data: {
-        id: "abc",
-        passport: {
-          data: {},
-        },
-        breadcrumbs: {},
-      },
-    };
-    const previewKeys: KeyPath[] = [];
-    const paymentAmountKey = "amount";
-    expect(() =>
-      validateSessionData({
-        session: invalidSession,
-        sessionPreviewKeys: previewKeys,
-        paymentAmountKey,
-      })
-    ).toThrow('invalid paymentAmount: "undefined"');
-  });
-  test("amount must be greater than zero", () => {
-    const invalidSession: Session = {
-      id: "abc",
-      flowId: "abc",
-      data: {
-        id: "abc",
-        passport: {
-          data: {
-            amount: -2,
-          },
-        },
-        breadcrumbs: {},
-      },
-    };
-    const previewKeys: KeyPath[] = [];
-    const paymentAmountKey = "amount";
-    expect(() =>
-      validateSessionData({
-        session: invalidSession,
-        sessionPreviewKeys: previewKeys,
-        paymentAmountKey,
-      })
-    ).toThrow('invalid paymentAmount: "-2"');
-    const invalidSession2: Session = {
-      id: "abc",
-      flowId: "abc",
-      data: {
-        id: "abc",
-        passport: {
-          data: {
-            amount: 0,
-          },
-        },
-        breadcrumbs: {},
-      },
-    };
-    expect(() =>
-      validateSessionData({
-        session: invalidSession2,
-        sessionPreviewKeys: previewKeys,
-        paymentAmountKey,
-      })
-    ).toThrow('invalid paymentAmount: "0"');
+    expect(() => extractSessionPreviewData(emptySession, previewKeys)).toThrow(
+      "passport data not found"
+    );
   });
   test("keys must be present in the passport", () => {
     const invalidSession: Session = {
@@ -97,20 +26,14 @@ describe("validateSessionData", () => {
         passport: {
           data: {
             key1: "a",
-            amount: 2,
           },
         },
         breadcrumbs: {},
       },
     };
     const previewKeys: KeyPath[] = [["key1"], ["key2", "notFoundKey"]];
-    const paymentAmountKey = "amount";
     expect(() =>
-      validateSessionData({
-        session: invalidSession,
-        sessionPreviewKeys: previewKeys,
-        paymentAmountKey,
-      })
+      extractSessionPreviewData(invalidSession, previewKeys)
     ).toThrow('passport key "key2.notFoundKey" not found in passport data');
   });
   test("a simple set of session preview keys are extracted from the session", () => {
@@ -124,7 +47,6 @@ describe("validateSessionData", () => {
             a: 1,
             b: 2,
             c: 3,
-            amount: 5,
           },
         },
         breadcrumbs: {},
@@ -132,14 +54,11 @@ describe("validateSessionData", () => {
     };
     const previewKeys: KeyPath[] = [["a"], ["b"], ["c"]];
 
-    const validatedSessionData = validateSessionData({
-      session: session,
-      sessionPreviewKeys: previewKeys,
-      paymentAmountKey: "amount",
-    });
-    expect(validatedSessionData).toEqual({
-      paymentAmount: 5,
-      sessionPreviewData: { a: 1, b: 2, c: 3 },
+    const sessionPreviewData = extractSessionPreviewData(session, previewKeys);
+    expect(sessionPreviewData).toEqual({
+      a: 1,
+      b: 2,
+      c: 3,
     });
   });
   test("a set of compound keys are extracted from the session", () => {
@@ -153,22 +72,14 @@ describe("validateSessionData", () => {
             "a.b": 1,
             "c.d": 2,
             "c.d.e": 3,
-            "payment.amount": 7,
           },
         },
         breadcrumbs: {},
       },
     };
     const previewKeys: KeyPath[] = [["a.b"], ["c.d"], ["c.d.e"]];
-    const validatedSessionData = validateSessionData({
-      session: session,
-      sessionPreviewKeys: previewKeys,
-      paymentAmountKey: "payment.amount",
-    });
-    expect(validatedSessionData).toEqual({
-      paymentAmount: 7,
-      sessionPreviewData: { "a.b": 1, "c.d": 2, "c.d.e": 3 },
-    });
+    const sessionPreviewData = extractSessionPreviewData(session, previewKeys);
+    expect(sessionPreviewData).toEqual({ "a.b": 1, "c.d": 2, "c.d.e": 3 });
   });
   test("a set of nested and compound keys are extracted from the session", () => {
     const session: Session = {
@@ -186,7 +97,6 @@ describe("validateSessionData", () => {
             b: {
               "c.d.e.f": false,
             },
-            "payment.amount": 7,
           },
         },
         breadcrumbs: {},
@@ -198,21 +108,14 @@ describe("validateSessionData", () => {
       ["a", "c.d.e"],
       ["b", "c.d.e.f"],
     ];
-    const validatedSessionData = validateSessionData({
-      session: session,
-      sessionPreviewKeys: previewKeys,
-      paymentAmountKey: "payment.amount",
-    });
-    expect(validatedSessionData).toEqual({
-      paymentAmount: 7,
-      sessionPreviewData: {
-        a: {
-          c: 0,
-          "c.d": true,
-          "c.d.e": 5,
-        },
-        b: { "c.d.e.f": false },
+    const sessionPreviewData = extractSessionPreviewData(session, previewKeys);
+    expect(sessionPreviewData).toEqual({
+      a: {
+        c: 0,
+        "c.d": true,
+        "c.d.e": 5,
       },
+      b: { "c.d.e.f": false },
     });
   });
 });

--- a/src/payment-request.test.ts
+++ b/src/payment-request.test.ts
@@ -13,12 +13,12 @@ describe("validateSessionData", () => {
       },
     };
     const previewKeys: KeyPath[] = [];
-    const amountKey = "amount";
+    const paymentAmountKey = "amount";
     expect(() =>
       validateSessionData({
         session: emptySession,
         sessionPreviewKeys: previewKeys,
-        amountKey,
+        paymentAmountKey,
       })
     ).toThrow("passport data not found");
   });
@@ -35,14 +35,14 @@ describe("validateSessionData", () => {
       },
     };
     const previewKeys: KeyPath[] = [];
-    const amountKey = "amount";
+    const paymentAmountKey = "amount";
     expect(() =>
       validateSessionData({
         session: invalidSession,
         sessionPreviewKeys: previewKeys,
-        amountKey,
+        paymentAmountKey,
       })
-    ).toThrow('invalid amount "undefined"');
+    ).toThrow('invalid paymentAmount: "undefined"');
   });
   test("amount must be greater than zero", () => {
     const invalidSession: Session = {
@@ -59,14 +59,14 @@ describe("validateSessionData", () => {
       },
     };
     const previewKeys: KeyPath[] = [];
-    const amountKey = "amount";
+    const paymentAmountKey = "amount";
     expect(() =>
       validateSessionData({
         session: invalidSession,
         sessionPreviewKeys: previewKeys,
-        amountKey,
+        paymentAmountKey,
       })
-    ).toThrow('invalid amount "-2"');
+    ).toThrow('invalid paymentAmount: "-2"');
     const invalidSession2: Session = {
       id: "abc",
       flowId: "abc",
@@ -84,9 +84,9 @@ describe("validateSessionData", () => {
       validateSessionData({
         session: invalidSession2,
         sessionPreviewKeys: previewKeys,
-        amountKey,
+        paymentAmountKey,
       })
-    ).toThrow('invalid amount "0"');
+    ).toThrow('invalid paymentAmount: "0"');
   });
   test("keys must be present in the passport", () => {
     const invalidSession: Session = {
@@ -104,12 +104,12 @@ describe("validateSessionData", () => {
       },
     };
     const previewKeys: KeyPath[] = [["key1"], ["key2", "notFoundKey"]];
-    const amountKey = "amount";
+    const paymentAmountKey = "amount";
     expect(() =>
       validateSessionData({
         session: invalidSession,
         sessionPreviewKeys: previewKeys,
-        amountKey,
+        paymentAmountKey,
       })
     ).toThrow('passport key "key2.notFoundKey" not found in passport data');
   });
@@ -135,10 +135,10 @@ describe("validateSessionData", () => {
     const validatedSessionData = validateSessionData({
       session: session,
       sessionPreviewKeys: previewKeys,
-      amountKey: "amount",
+      paymentAmountKey: "amount",
     });
     expect(validatedSessionData).toEqual({
-      amount: 5,
+      paymentAmount: 5,
       sessionPreviewData: { a: 1, b: 2, c: 3 },
     });
   });
@@ -163,10 +163,10 @@ describe("validateSessionData", () => {
     const validatedSessionData = validateSessionData({
       session: session,
       sessionPreviewKeys: previewKeys,
-      amountKey: "payment.amount",
+      paymentAmountKey: "payment.amount",
     });
     expect(validatedSessionData).toEqual({
-      amount: 7,
+      paymentAmount: 7,
       sessionPreviewData: { "a.b": 1, "c.d": 2, "c.d.e": 3 },
     });
   });
@@ -201,10 +201,10 @@ describe("validateSessionData", () => {
     const validatedSessionData = validateSessionData({
       session: session,
       sessionPreviewKeys: previewKeys,
-      amountKey: "payment.amount",
+      paymentAmountKey: "payment.amount",
     });
     expect(validatedSessionData).toEqual({
-      amount: 7,
+      paymentAmount: 7,
       sessionPreviewData: {
         a: {
           c: 0,

--- a/src/payment-request.ts
+++ b/src/payment-request.ts
@@ -4,31 +4,28 @@ import { getLatestFlowGraph } from "./flow";
 import keyPathAccessor from "lodash.property";
 import setByKeyPath from "lodash.set";
 import { ComponentType } from "./types";
-import type {
-  PaymentRequest,
-  Session,
-  KeyPath,
-  Value,
-  Breadcrumbs,
-} from "./types";
+import { sortFlow, sortBreadcrumbs } from "./logic";
+import type { PaymentRequest, Session, KeyPath, Value } from "./types";
 
-type ValidatedSessionData = {
-  sessionPreviewData: PaymentRequest["sessionPreviewData"];
-  paymentAmount: number;
+type PayNode = {
+  type: ComponentType.Pay;
+  data: { fn: string | undefined };
 };
 
 export async function createPaymentRequest(
   client: GraphQLClient,
   {
     sessionId,
-    sessionPreviewKeys,
+    applicantName,
     payeeName,
     payeeEmail,
+    sessionPreviewKeys,
   }: {
     sessionId: string;
-    sessionPreviewKeys: KeyPath[];
+    applicantName: string;
     payeeName: string;
     payeeEmail: string;
+    sessionPreviewKeys: KeyPath[];
   }
 ): Promise<PaymentRequest> {
   const session = await getDetailedSessionById(client, sessionId);
@@ -41,112 +38,140 @@ export async function createPaymentRequest(
     );
   }
 
+  // build sessionPreviewData using sessionPreviewKeys
+  // this throws if data is missing/invalid
+  const sessionPreviewData = extractSessionPreviewData(
+    session,
+    sessionPreviewKeys
+  );
+
   // payment requests can only be created for flows with a pay component
   // this throws if the pay component cannot be found
-  const paymentAmountKey: string = await getPaymentAmountKey({
-    client,
-    flowId: session.flowId,
-    breadcrumbs: session.data?.breadcrumbs,
-  });
-
-  // build sessionPreviewData using sessionPreviewKeys and the paymentAmountKey
-  // this throws if data is missing/invalid
-  const validatedSessionData: ValidatedSessionData = validateSessionData({
-    session,
-    sessionPreviewKeys,
-    paymentAmountKey,
-  });
+  const paymentAmount = await getPaymentAmount(client, session);
+  if (
+    !paymentAmount ||
+    paymentAmount <= 0 ||
+    !Number.isInteger(paymentAmount)
+  ) {
+    throw new Error(
+      `payment amount must be a positive integer but was "${paymentAmount}"`
+    );
+  }
 
   const response: Record<"insert_payment_requests_one", PaymentRequest> =
     await client.request(
       gql`
         mutation CreatePaymentRequest(
           $sessionId: uuid!
+          $applicantName: String!
           $payeeName: String!
           $payeeEmail: String!
+          $paymentAmount: Int!
           $sessionPreviewData: jsonb!
         ) {
           insert_payment_requests_one(
             object: {
               session_id: $sessionId
+              applicant_name: $applicantName
               payee_name: $payeeName
               payee_email: $payeeEmail
+              payment_amount: $paymentAmount
               session_preview_data: $sessionPreviewData
             }
           ) {
             id
             sessionId: session_id
+            applicantName: applicant_name
             payeeName: payee_name
             payeeEmail: payee_email
+            paymentAmount: payment_amount
             sessionPreviewData: session_preview_data
           }
         }
       `,
       {
         sessionId,
+        applicantName,
         payeeName,
         payeeEmail,
-        sessionPreviewData: validatedSessionData.sessionPreviewData,
-        //TODO paymentAmount: validatedSessionData.paymentAmount
+        paymentAmount,
+        sessionPreviewData,
       }
     );
   return response?.insert_payment_requests_one;
 }
 
-// lookup the "paymentAmount" passport key from the pay component of a given flow
-async function getPaymentAmountKey({
-  client,
-  flowId,
-  breadcrumbs,
-}: {
-  client: GraphQLClient;
-  flowId: string;
-  breadcrumbs: Breadcrumbs | undefined;
-}): Promise<string> {
-  if (!breadcrumbs) {
-    throw new Error("breadcrumbs not found");
-  }
-  const flowGraph = await getLatestFlowGraph(client, flowId);
-  if (!flowGraph) {
-    throw new Error("flow not found");
-  }
-  for (const [crumbId, _] of Object.entries(breadcrumbs)) {
-    const node = flowGraph[crumbId];
-    if (node.type === ComponentType.Pay) {
-      return (node.data?.fn as string) || "amount";
-    }
-  }
-  throw new Error("flow must contain a pay node");
-}
-
-export function validateSessionData({
-  session,
-  sessionPreviewKeys,
-  paymentAmountKey,
-}: {
-  session: Session;
-  sessionPreviewKeys: KeyPath[];
-  paymentAmountKey: string;
-}): ValidatedSessionData {
+export function extractSessionPreviewData(
+  session: Session,
+  sessionPreviewKeys: KeyPath[]
+): PaymentRequest["sessionPreviewData"] {
   if (!session.data.passport?.data) {
     throw new Error("passport data not found");
   }
-  const data = session.data.passport.data!;
-  const paymentAmount = data[paymentAmountKey];
-  if (!paymentAmount || paymentAmount <= 0) {
-    throw new Error(`invalid paymentAmount: "${paymentAmount}"`);
-  }
+  const passport = session.data.passport.data!;
   const sessionPreviewData: PaymentRequest["sessionPreviewData"] = {};
   sessionPreviewKeys.forEach((keyPath: KeyPath) => {
-    const value = keyPathAccessor(keyPath)(data);
+    const value = keyPathAccessor(keyPath)(passport);
     if (value === undefined) {
       const stringKey = keyPath.join(".");
       throw new Error(`passport key "${stringKey}" not found in passport data`);
     }
     setByKeyPath(sessionPreviewData, keyPath, value as Value);
   });
-  return {
-    sessionPreviewData,
-    paymentAmount,
-  };
+  return sessionPreviewData;
+}
+
+// find the payment set in the passport
+async function getPaymentAmount(
+  client: GraphQLClient,
+  session: Session
+): Promise<number | undefined> {
+  if (!session.data?.breadcrumbs) {
+    throw new Error("breadcrumbs not found");
+  }
+  const breadcrumbs = session.data.breadcrumbs!;
+
+  if (!session.data?.passport?.data) {
+    throw new Error("passport not found");
+  }
+  const passport = session.data.passport.data!;
+
+  const flowId = session.flowId;
+  const flowGraph = await getLatestFlowGraph(client, flowId);
+  if (!flowGraph) {
+    throw new Error("flow not found");
+  }
+
+  const orderedBreadcrumbs = sortBreadcrumbs(flowGraph, breadcrumbs);
+  const lastCrumb = orderedBreadcrumbs.at(-1)!;
+
+  // if breadcrumbs includes the pay node
+  // use its key to find the pay amount in the passport
+  if (lastCrumb.type === ComponentType.Pay) {
+    const amountKey = getPaymentAmountKeyFromNode(
+      flowGraph[lastCrumb.id] as PayNode
+    );
+    return passport[amountKey];
+  }
+
+  // otherwise the pay node may not have been enterd into breadcrumbs so
+  // find the next node that is a pay component and use its key to find
+  // the pay amount in the passport
+  for (const node of sortFlow(flowGraph)) {
+    const isNextNodeAfterLastCrumb = node.parentId === lastCrumb.id;
+    if (isNextNodeAfterLastCrumb && node.type === ComponentType.Pay) {
+      const amountKey = getPaymentAmountKeyFromNode(
+        flowGraph[node.id] as PayNode
+      );
+      return passport[amountKey];
+    }
+  }
+
+  // throw if a pay component was not found
+  throw new Error("could not find a pay node");
+}
+
+function getPaymentAmountKeyFromNode(payNode: PayNode) {
+  const defaultPaymentKey = "application.fee.payable";
+  return payNode.data.fn || defaultPaymentKey;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,8 +94,8 @@ export interface NormalizedCrumb extends Crumb {
   autoAnswered: boolean;
   sectionId?: string;
   answers?: Array<string>;
-  data?: Record<string, Value>
-  override?: Record<string, Value>
+  data?: Record<string, Value>;
+  override?: Record<string, Value>;
   feedback?: string;
 }
 
@@ -228,8 +228,10 @@ export interface DetailedSession extends Session {
 
 export interface PaymentRequest {
   id: string;
+  applicantName: string;
   sessionId: string;
   payeeName: string;
   payeeEmail: string;
+  paymentAmount: number;
   sessionPreviewData: { [key: string]: Value };
 }


### PR DESCRIPTION
Payment requests can only be created for flows with a pay component. This adds a lookup for the "amount" passport key from the pay component and add it to sessionPreviewKeys if it exists and fails the payment request creation if not.