### PR TITLE
feat: Add authorizeSession to graphql client

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -3,11 +3,23 @@ import { GraphQLClient } from "graphql-request";
 export function graphQLClient({
   url,
   secret,
+  authorizedSession,
 }: {
   url: string;
-  secret?: string | undefined;
+  secret?: string;
+  authorizedSession?: {
+    email: string;
+    sessionId: string;
+  };
 }): GraphQLClient {
   let headers = {};
-  if (secret) headers = { "X-Hasura-Admin-Secret": secret };
+  if (secret) {
+    headers = { "x-hasura-admin-secret": secret };
+  } else if (authorizedSession) {
+    headers = {
+      "x-hasura-lowcal-session-id": authorizedSession.sessionId,
+      "x-hasura-lowcal-email": authorizedSession.email,
+    };
+  }
   return new GraphQLClient(url, { headers });
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -28,6 +28,25 @@ describe("CoreDomainClient", () => {
     });
     expect(core).toBeInstanceOf(CoreDomainClient);
   });
+
+  test("a public client can authorize a session", () => {
+    const core = new CoreDomainClient();
+    core.authorizeSession({ email: "blah@email.com", sessionId: "1234" });
+    expect(core.client.requestConfig.headers).toEqual({
+      "x-hasura-lowcal-session-id": "1234",
+      "x-hasura-lowcal-email": "blah@email.com",
+    });
+  });
+
+  test("an admin client cannot authorize a session", () => {
+    const core = new CoreDomainClient({
+      hasuraSecret: "shhh...",
+      targetURL: "https://example.com",
+    });
+    expect(() =>
+      core.authorizeSession({ email: "blah@email.com", sessionId: "1234" })
+    ).toThrow();
+  });
 });
 
 describe("Logic", () => {


### PR DESCRIPTION
This method allows a public client to access data for a given session by amending the GraphQL headers of the client.