### PR TITLE
feat: Add namespaced clients

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "lodash.property": "^4.4.2",
     "lodash.set": "^4.3.2",
     "type-fest": "^3.8.0",
+    "uuid": "^9.0.0",
     "zod": "^3.21.4"
   },
   "devDependencies": {
@@ -65,6 +66,7 @@
     "@types/lodash.property": "^4.4.7",
     "@types/lodash.set": "^4.3.7",
     "@types/node": "^18.16.0",
+    "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "^5.59.1",
     "@typescript-eslint/parser": "^5.59.1",
     "esbuild": "^0.17.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ specifiers:
   '@types/lodash.property': ^4.4.7
   '@types/lodash.set': ^4.3.7
   '@types/node': ^18.16.0
+  '@types/uuid': ^9.0.1
   '@typescript-eslint/eslint-plugin': ^5.59.1
   '@typescript-eslint/parser': ^5.59.1
   esbuild: ^0.17.18
@@ -38,6 +39,7 @@ specifiers:
   ts-node: ^10.9.1
   type-fest: ^3.8.0
   typescript: ^4.9.5
+  uuid: ^9.0.0
   zod: ^3.21.4
 
 dependencies:
@@ -55,6 +57,7 @@ dependencies:
   lodash.property: 4.4.2
   lodash.set: 4.3.2
   type-fest: 3.9.0
+  uuid: 9.0.0
   zod: 3.21.4
 
 devDependencies:
@@ -70,6 +73,7 @@ devDependencies:
   '@types/lodash.property': 4.4.7
   '@types/lodash.set': 4.3.7
   '@types/node': 18.16.7
+  '@types/uuid': 9.0.1
   '@typescript-eslint/eslint-plugin': 5.59.5_jdo46vuzdvtqioigt7za7mzwma
   '@typescript-eslint/parser': 5.59.5_jgkqkwom7vrxl4kyi454n2sy2i
   esbuild: 0.17.18
@@ -1611,6 +1615,10 @@ packages:
   /@types/trusted-types/2.0.3:
     resolution: {integrity: sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==}
     dev: false
+
+  /@types/uuid/9.0.1:
+    resolution: {integrity: sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==}
+    dev: true
 
   /@types/yargs-parser/21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
@@ -5103,6 +5111,11 @@ packages:
 
   /util-deprecate/1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    dev: false
+
+  /uuid/9.0.0:
+    resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
+    hasBin: true
     dev: false
 
   /v8-compile-cache-lib/3.0.1:

--- a/src/requests/application.ts
+++ b/src/requests/application.ts
@@ -112,14 +112,14 @@ export async function _destroyBopsApplication(
     await client.request(
       gql`
         mutation DestroyBopsApplication($sessionId: String!) {
-          delete_bops_applications_by_pk(id: $sessionId) {
-            id
+          delete_bops_applications(where: { session_id: { _eq: $sessionId } }) {
+            affected_rows
           }
         }
       `,
       { sessionId }
     );
-  return Boolean(response.delete_bops_applications_by_pk?.id);
+  return Boolean(response.delete_bops_applications?.affected_rows);
 }
 
 export async function _destroyEmailApplication(
@@ -130,14 +130,16 @@ export async function _destroyEmailApplication(
     await client.request(
       gql`
         mutation DestroyEmailApplication($sessionId: uuid!) {
-          delete_email_applications_by_pk(id: $sessionId) {
-            id
+          delete_email_applications(
+            where: { session_id: { _eq: $sessionId } }
+          ) {
+            affected_rows
           }
         }
       `,
       { sessionId }
     );
-  return Boolean(response.delete_email_applications_by_pk?.id);
+  return Boolean(response.delete_email_applications?.affected_rows);
 }
 
 export async function _destroyUniformApplication(
@@ -148,12 +150,14 @@ export async function _destroyUniformApplication(
     await client.request(
       gql`
         mutation DestroyUniformApplication($sessionId: String!) {
-          delete_uniform_applications_by_pk(id: $sessionId) {
-            id
+          delete_uniform_applications(
+            where: { submission_reference: { _eq: $sessionId } }
+          ) {
+            affected_rows
           }
         }
       `,
       { sessionId }
     );
-  return Boolean(response.delete_uniform_applications_by_pk?.id);
+  return Boolean(response.delete_uniform_applications?.affected_rows);
 }

--- a/src/requests/application.ts
+++ b/src/requests/application.ts
@@ -1,0 +1,97 @@
+import { gql, GraphQLClient } from "graphql-request";
+import type { ApplicationResponse } from "../types";
+
+export class ApplicationClient {
+  protected client: GraphQLClient;
+
+  constructor(client: GraphQLClient) {
+    this.client = client;
+  }
+
+  async bopsResponse(sessionId: string): Promise<ApplicationResponse | null> {
+    return bopsApplicationResponse(this.client, sessionId);
+  }
+
+  async emailResponse(sessionId: string): Promise<ApplicationResponse | null> {
+    return emailApplicationResponse(this.client, sessionId);
+  }
+
+  async uniformResponse(
+    sessionId: string
+  ): Promise<ApplicationResponse | null> {
+    return uniformApplicationResponse(this.client, sessionId);
+  }
+}
+
+export async function uniformApplicationResponse(
+  client: GraphQLClient,
+  sessionId: string
+): Promise<ApplicationResponse | null> {
+  const response: {
+    uniform_applications: { response: ApplicationResponse | null }[];
+  } = await client.request(
+    gql`
+      query GetUniformApplicationResponse($sessionId: String!) {
+        uniform_applications(
+          where: { submission_reference: { _eq: $sessionId } }
+          order_by: { created_at: desc }
+          limit: 1
+        ) {
+          response
+        }
+      }
+    `,
+    { sessionId }
+  );
+  return response.uniform_applications.length > 0
+    ? response.uniform_applications[0].response
+    : null;
+}
+
+export async function bopsApplicationResponse(
+  client: GraphQLClient,
+  sessionId: string
+): Promise<ApplicationResponse | null> {
+  const response: { bops_applications: { response: ApplicationResponse }[] } =
+    await client.request(
+      gql`
+        query GetBOPSApplicationResponse($sessionId: String!) {
+          bops_applications(
+            where: { session_id: { _eq: $sessionId } }
+            order_by: { created_at: desc }
+            limit: 1
+          ) {
+            response
+          }
+        }
+      `,
+      { sessionId }
+    );
+  return response.bops_applications.length > 0
+    ? response.bops_applications[0].response
+    : null;
+}
+
+export async function emailApplicationResponse(
+  client: GraphQLClient,
+  sessionId: string
+): Promise<ApplicationResponse | null> {
+  const response: { email_applications: { response: ApplicationResponse }[] } =
+    await client.request(
+      gql`
+        query GetEmailApplicationResponse($sessionId: uuid!) {
+          email_applications(
+            where: { session_id: { _eq: $sessionId } }
+            order_by: { created_at: desc }
+            limit: 1
+          ) {
+            response
+          }
+        }
+      `,
+      { sessionId }
+    );
+  return response.email_applications.length > 0
+    ? response.email_applications[0].response
+    : null;
+}

--- a/src/requests/application.ts
+++ b/src/requests/application.ts
@@ -111,7 +111,7 @@ export async function _destroyBopsApplication(
   const response: { delete_bops_applications_by_pk: { id: string } | null } =
     await client.request(
       gql`
-        mutation DestroyBopsApplication($sessionId: uuid!) {
+        mutation DestroyBopsApplication($sessionId: String!) {
           delete_bops_applications_by_pk(id: $sessionId) {
             id
           }
@@ -147,7 +147,7 @@ export async function _destroyUniformApplication(
   const response: { delete_uniform_applications_by_pk: { id: string } | null } =
     await client.request(
       gql`
-        mutation DestroyUniformApplication($sessionId: uuid!) {
+        mutation DestroyUniformApplication($sessionId: String!) {
           delete_uniform_applications_by_pk(id: $sessionId) {
             id
           }

--- a/src/requests/application.ts
+++ b/src/requests/application.ts
@@ -108,7 +108,7 @@ export async function _destroyBopsApplication(
   client: GraphQLClient,
   sessionId: string
 ): Promise<boolean> {
-  const response: { delete_bops_applications_by_pk: { id: string } | null } =
+  const response: { delete_bops_applications: { affected_rows: number } } =
     await client.request(
       gql`
         mutation DestroyBopsApplication($sessionId: String!) {
@@ -126,7 +126,7 @@ export async function _destroyEmailApplication(
   client: GraphQLClient,
   sessionId: string
 ): Promise<boolean> {
-  const response: { delete_email_applications_by_pk: { id: string } | null } =
+  const response: { delete_email_applications: { affected_rows: number } } =
     await client.request(
       gql`
         mutation DestroyEmailApplication($sessionId: uuid!) {
@@ -146,7 +146,7 @@ export async function _destroyUniformApplication(
   client: GraphQLClient,
   sessionId: string
 ): Promise<boolean> {
-  const response: { delete_uniform_applications_by_pk: { id: string } | null } =
+  const response: { delete_uniform_applications: { affected_rows: number } } =
     await client.request(
       gql`
         mutation DestroyUniformApplication($sessionId: String!) {

--- a/src/requests/application.ts
+++ b/src/requests/application.ts
@@ -21,6 +21,14 @@ export class ApplicationClient {
   ): Promise<ApplicationResponse | null> {
     return uniformApplicationResponse(this.client, sessionId);
   }
+
+  async _destroyAll(sessionId: string): Promise<void> {
+    await Promise.all([
+      _destroyBopsApplication(this.client, sessionId),
+      _destroyEmailApplication(this.client, sessionId),
+      _destroyUniformApplication(this.client, sessionId),
+    ]);
+  }
 }
 
 export async function uniformApplicationResponse(
@@ -94,4 +102,58 @@ export async function emailApplicationResponse(
   return response.email_applications.length > 0
     ? response.email_applications[0].response
     : null;
+}
+
+export async function _destroyBopsApplication(
+  client: GraphQLClient,
+  sessionId: string
+): Promise<boolean> {
+  const response: { delete_bops_applications_by_pk: { id: string } | null } =
+    await client.request(
+      gql`
+        mutation DestroyBopsApplication($sessionId: uuid!) {
+          delete_bops_applications_by_pk(id: $sessionId) {
+            id
+          }
+        }
+      `,
+      { sessionId }
+    );
+  return Boolean(response.delete_bops_applications_by_pk?.id);
+}
+
+export async function _destroyEmailApplication(
+  client: GraphQLClient,
+  sessionId: string
+): Promise<boolean> {
+  const response: { delete_email_applications_by_pk: { id: string } | null } =
+    await client.request(
+      gql`
+        mutation DestroyEmailApplication($sessionId: uuid!) {
+          delete_email_applications_by_pk(id: $sessionId) {
+            id
+          }
+        }
+      `,
+      { sessionId }
+    );
+  return Boolean(response.delete_email_applications_by_pk?.id);
+}
+
+export async function _destroyUniformApplication(
+  client: GraphQLClient,
+  sessionId: string
+): Promise<boolean> {
+  const response: { delete_uniform_applications_by_pk: { id: string } | null } =
+    await client.request(
+      gql`
+        mutation DestroyUniformApplication($sessionId: uuid!) {
+          delete_uniform_applications_by_pk(id: $sessionId) {
+            id
+          }
+        }
+      `,
+      { sessionId }
+    );
+  return Boolean(response.delete_uniform_applications_by_pk?.id);
 }

--- a/src/requests/user.ts
+++ b/src/requests/user.ts
@@ -1,6 +1,26 @@
 import { gql } from "graphql-request";
 import type { GraphQLClient } from "graphql-request";
 
+export class UserClient {
+  protected client: GraphQLClient;
+
+  constructor(client: GraphQLClient) {
+    this.client = client;
+  }
+
+  async create(args: {
+    firstName: string;
+    lastName: string;
+    email: string;
+  }): Promise<number> {
+    return createUser(this.client, args);
+  }
+
+  async _destroy(userId: number): Promise<boolean> {
+    return _destroyUser(this.client, userId);
+  }
+}
+
 export async function createUser(
   client: GraphQLClient,
   args: { firstName: string; lastName: string; email: string }
@@ -30,4 +50,22 @@ export async function createUser(
     }
   );
   return response.insert_users_one.id;
+}
+
+export async function _destroyUser(
+  client: GraphQLClient,
+  userId: number
+): Promise<boolean> {
+  const response: { delete_users_by_pk: { id: number } | null } =
+    await client.request(
+      gql`
+        mutation DestroyUser($userId: Int!) {
+          delete_users_by_pk(id: $userId) {
+            id
+          }
+        }
+      `,
+      { userId }
+    );
+  return Boolean(response.delete_users_by_pk?.id);
 }

--- a/src/types/application.ts
+++ b/src/types/application.ts
@@ -1,0 +1,1 @@
+export type ApplicationResponse = Record<string, unknown>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,3 +8,4 @@ export * from "./session";
 export * from "./payment-request";
 export * from "./result";
 export * from "./planning-constraints";
+export * from "./application";

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -17,6 +17,7 @@ export interface Session {
 
 export interface DetailedSession extends Session {
   lockedAt: string;
+  submittedAt: string;
 }
 
 export interface Crumb {


### PR DESCRIPTION
The purpose of this PR is to introduce some new request functions used in e2e testing.

Rather than adding to an ever-growing set of exported request functions in one file, here I'm introducing namespaced clients. Each client exposes a nice simple interface within a namespace of the main client (e.g. `client.session.lock("123")`).

Used by https://github.com/theopensystemslab/planx-new/pull/1743