### PR TITLE
fix: Check payment has not already been initialised before generating payment request

### DIFF
--- a/src/requests/payment-request.ts
+++ b/src/requests/payment-request.ts
@@ -62,6 +62,11 @@ export async function createPaymentRequest(
       "session must be locked before a payment request can be created"
     );
   }
+  if (session.data.govUkPayment) {
+    throw new Error(
+      "cannot initiate a new payment request for a session which already has a GovUKPayment initialised"
+    );
+  }
 
   // build sessionPreviewData using sessionPreviewKeys
   // this throws if data is missing/invalid


### PR DESCRIPTION
Better handling to help address issue described here - https://trello.com/c/2n0EJ3wA/1635-invite-to-pay-epic#comment-6481a3db0d31432020c497bf

Implementation and tested in https://github.com/theopensystemslab/planx-new/pull/1773