### PR TITLE
ci: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm" # use this yaml value when package manager is 'pnpm'
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "theopensystemslab/planx"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule: 
+      interval: "weekly"
+    reviewers:
+      - "theopensystemslab/planx"


### PR DESCRIPTION
no env vars in this repo, so I think this should just work as-is without needing to grant dependabot access to any secrets.