### PR TITLE
fix: Handle missing raw project types

### DIFF
--- a/src/requests/index.ts
+++ b/src/requests/index.ts
@@ -171,7 +171,7 @@ export class CoreDomainClient {
    * console.log(result)
    * // Logs "Addition of a swimming pool, rear extension, and new window installation"
    */
-  async formatRawProjectTypes(rawProjectTypes: string[]): Promise<string> {
+  async formatRawProjectTypes(rawProjectTypes: string[] = []): Promise<string> {
     return formatRawProjectTypes(this.client, rawProjectTypes);
   }
 }


### PR DESCRIPTION
If we run a GraphQl `_in` query on an `undefined` value, we get the following error - 

```json
{
  "errors": [
    {
      "extensions": {
        "path": "$.selectionSet.project_types.args.where.value._in",
        "code": "validation-failed"
      },
      "message": "expected a list, but found null"
    }
  ]
}
```

I can currently hit this error when hitting the `/resume-application` endpoint for my OSL email.