### PR TITLE
fix: remove `portal_name` from BOPS export format

### DIFF
--- a/src/export/bops/index.ts
+++ b/src/export/bops/index.ts
@@ -9,7 +9,6 @@ import {
   FlowGraph,
   GOV_PAY_PASSPORT_KEY,
   GovUKPayment,
-  Node,
   Passport,
   flatFlags,
 } from "../../types";
@@ -98,40 +97,6 @@ export function formatProposalDetails({
   feedback?: BOPSFullPayload["feedback"];
 } {
   const sortedBreadcrumbs = sortBreadcrumbs(flow, breadcrumbs);
-
-  // find all internal portals and check those
-  const portals: { id: string; name: string; edges: string[] | undefined }[] =
-    Object.entries(flow)
-      .filter(([_, node]) => {
-        const n = node as Node;
-        // internal & external portals are both type InternalPortal after flattening (ref dataMergedHotFix)
-        return n.type && n.type === ComponentType.InternalPortal;
-      })
-      .map(([nodeId, node]) => {
-        const n = node as Node;
-        return {
-          id: nodeId,
-          name: (n.data?.text as string) || nodeId,
-          edges: n.edges,
-        };
-      })
-      .concat([{ id: "_root", name: "_root", edges: flow._root.edges }])
-      .reverse();
-
-  const portalName = (id: string): string | undefined => {
-    if (id === "_root") return "_root";
-    for (const portal of portals) {
-      if (portal.edges?.includes(id)) {
-        return portal.name;
-      }
-    }
-    for (const [nodeId, node] of Object.entries(flow)) {
-      if (node.edges?.includes(id)) {
-        const name = portalName(nodeId);
-        if (name) return name;
-      }
-    }
-  };
 
   const feedback: BOPSFullPayload["feedback"] = {};
   const proposalDetails: Array<QuestionAndResponses> = [];
@@ -231,9 +196,7 @@ export function formatProposalDetails({
     });
 
     const metadata = (() => {
-      const metadata: QuestionMetaData = {
-        portal_name: portalName(crumb.id),
-      };
+      const metadata: QuestionMetaData = {};
       if (hasSections) {
         metadata.section_name = currentSectionName;
       }

--- a/src/export/bops/mocks/payload.ts
+++ b/src/export/bops/mocks/payload.ts
@@ -1121,7 +1121,7 @@ export const mockExpectedBOPSPayload = {
   proposal_details: [
     {
       metadata: {
-        portal_name: "_root",
+        
         auto_answered: true,
       },
       question: "Is the property in London Borough of Lambeth?",
@@ -1138,7 +1138,7 @@ export const mockExpectedBOPSPayload = {
             text: "Town and Country Planning Act 1990, Part 7, Section 191 &amp; Section 192",
           },
         ],
-        portal_name: "_root",
+        
       },
       question: "What are you applying about?",
       responses: [
@@ -1154,7 +1154,6 @@ export const mockExpectedBOPSPayload = {
             text: "Town and Country Planning Act 1990 (Section 55), The Town and Country Planning (General Permitted Development) (England) Order 2015",
           },
         ],
-        portal_name: "permitteddevelopment",
       },
       question: "List the changes involved in the project",
       responses: [
@@ -1170,7 +1169,6 @@ export const mockExpectedBOPSPayload = {
             text: "Town and Country Planning Act 1990, Section 55 (2)",
           },
         ],
-        portal_name: "Alarms",
         auto_answered: true,
       },
       question: "Is the property in a conservation area?",
@@ -1185,7 +1183,7 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "_root",
+        
         auto_answered: true,
       },
       question: "Is the property subject to any Article 4 directions?",
@@ -1197,7 +1195,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "works-to-trees-filter",
         auto_answered: true,
       },
       question: "What types of changes does the project involve?",
@@ -1209,7 +1206,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "works-to-trees-filter",
         auto_answered: true,
       },
       question:
@@ -1222,7 +1218,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "works-to-trees-filter",
         auto_answered: true,
       },
       question: "Are there any protected trees on the property?",
@@ -1234,7 +1229,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "works-to-trees-filter",
         auto_answered: true,
       },
       question: "Is the site in a conservation area?",
@@ -1249,7 +1243,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "Warnings",
         auto_answered: true,
       },
       question: "Is any part of the property listed?",
@@ -1264,7 +1257,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "Warnings",
         auto_answered: true,
       },
       question: "Should the applicant also apply for Works to Trees Consent?",
@@ -1276,7 +1268,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "more-details",
         auto_answered: true,
       },
       question: "What are you applying about?",
@@ -1288,7 +1279,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "more-details",
         auto_answered: true,
       },
       question: "What do the works involve?",
@@ -1300,7 +1290,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "more-details",
         auto_answered: true,
       },
       question: "What does the project involve?",
@@ -1312,7 +1301,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "more-details",
         auto_answered: true,
       },
       question: "Do the changes involve the creation of any new homes?",
@@ -1329,7 +1317,6 @@ export const mockExpectedBOPSPayload = {
             text: "Greater London Authority Act 1999",
           },
         ],
-        portal_name: "more-details",
         auto_answered: true,
       },
       question: "Is the property in the Greater London Authority area?",
@@ -1346,7 +1333,6 @@ export const mockExpectedBOPSPayload = {
             text: "Greater London Authority Act 1999",
           },
         ],
-        portal_name: "London Datahub",
       },
       question: "How many properties are on the site?",
       responses: [
@@ -1356,9 +1342,7 @@ export const mockExpectedBOPSPayload = {
       ],
     },
     {
-      metadata: {
-        portal_name: "London Datahub",
-      },
+      metadata: {},
       question: "Do you know the title number of the property?",
       responses: [
         {
@@ -1373,7 +1357,6 @@ export const mockExpectedBOPSPayload = {
             text: "Greater London Authority Act 1999",
           },
         ],
-        portal_name: "London Datahub",
       },
       question:
         "Does the property have an Energy Performance Certificate (EPC)?",
@@ -1390,7 +1373,6 @@ export const mockExpectedBOPSPayload = {
             text: "Greater London Authority Act 1999",
           },
         ],
-        portal_name: "London Datahub",
         auto_answered: true,
       },
       question: "What type of application is this?",
@@ -1407,7 +1389,6 @@ export const mockExpectedBOPSPayload = {
             text: "Greater London Authority Act 1999",
           },
         ],
-        portal_name: "London Datahub",
       },
       question: "When will the works start?",
       responses: [
@@ -1423,7 +1404,6 @@ export const mockExpectedBOPSPayload = {
             text: "Greater London Authority Act 1999",
           },
         ],
-        portal_name: "London Datahub",
       },
       question: "When will the works be completed?",
       responses: [
@@ -1439,7 +1419,6 @@ export const mockExpectedBOPSPayload = {
             text: "Greater London Authority Act 1999",
           },
         ],
-        portal_name: "London Datahub",
       },
       question: "Does the site include parking spaces for any of these?",
       responses: [
@@ -1449,9 +1428,7 @@ export const mockExpectedBOPSPayload = {
       ],
     },
     {
-      metadata: {
-        portal_name: "about-the-applicant",
-      },
+      metadata: {},
       question: "Are you applying on behalf of someone else?",
       responses: [
         {
@@ -1460,9 +1437,7 @@ export const mockExpectedBOPSPayload = {
       ],
     },
     {
-      metadata: {
-        portal_name: "about-the-applicant",
-      },
+      metadata: {},
       question: "Which of these best describes you (or your organisation)?",
       responses: [
         {
@@ -1471,9 +1446,7 @@ export const mockExpectedBOPSPayload = {
       ],
     },
     {
-      metadata: {
-        portal_name: "about-the-applicant",
-      },
+      metadata: {},
       question: "Your contact details",
       responses: [
         {
@@ -1482,9 +1455,7 @@ export const mockExpectedBOPSPayload = {
       ],
     },
     {
-      metadata: {
-        portal_name: "about-the-applicant",
-      },
+      metadata: {},
       question: "Is your contact address the same as the property address?",
       responses: [
         {
@@ -1493,9 +1464,7 @@ export const mockExpectedBOPSPayload = {
       ],
     },
     {
-      metadata: {
-        portal_name: "about-the-applicant",
-      },
+      metadata: {},
       question:
         "We may need to visit your site to assess your application. If we do, who should we contact to arrange the visit?",
       responses: [
@@ -1506,7 +1475,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "ownership",
         auto_answered: true,
       },
       question: "Which of these best describes you?",
@@ -1523,7 +1491,6 @@ export const mockExpectedBOPSPayload = {
             text: "The Town and Country Planning (Development Management Procedure) (England) Order 2015",
           },
         ],
-        portal_name: "ownership",
       },
       question: "Which of these best describes your interest in the land?",
       responses: [
@@ -1539,7 +1506,6 @@ export const mockExpectedBOPSPayload = {
             text: "[Town and Country Planning Act 1990 Section 171B](https://www.legislation.gov.uk/ukpga/1990/8/section/171B)",
           },
         ],
-        portal_name: "_root",
         auto_answered: true,
       },
       question: "What are you applying about?",
@@ -1551,7 +1517,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "certificate-of-lawfulness-proposed-drawings",
         auto_answered: true,
       },
       question: "What types of changes does the project involve?",
@@ -1563,7 +1528,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "certificate-of-lawfulness-proposed-drawings",
         auto_answered: true,
       },
       question:
@@ -1575,9 +1539,7 @@ export const mockExpectedBOPSPayload = {
       ],
     },
     {
-      metadata: {
-        portal_name: "certificate-of-lawfulness-proposed-drawings",
-      },
+      metadata: {},
       question:
         "Will the works involve altering the appearance or layout of any roof?",
       responses: [
@@ -1587,9 +1549,7 @@ export const mockExpectedBOPSPayload = {
       ],
     },
     {
-      metadata: {
-        portal_name: "certificate-of-lawfulness-proposed-drawings",
-      },
+      metadata: {},
       question:
         "Does the work involve any alterations to ground or floor levels?",
       responses: [
@@ -1599,9 +1559,7 @@ export const mockExpectedBOPSPayload = {
       ],
     },
     {
-      metadata: {
-        portal_name: "certificate-of-lawfulness-proposed-drawings",
-      },
+      metadata: {},
       question: "Would you like to upload any photographs?",
       responses: [
         {
@@ -1610,9 +1568,7 @@ export const mockExpectedBOPSPayload = {
       ],
     },
     {
-      metadata: {
-        portal_name: "certificate-of-lawfulness-proposed-drawings",
-      },
+      metadata: {},
       question:
         "Would you like to upload any additional drawings, documents or images?",
       responses: [
@@ -1623,7 +1579,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "fee-calculator",
         auto_answered: true,
       },
       question: "What type of planning application are you making?",
@@ -1635,7 +1590,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "fee-calculator",
         auto_answered: true,
       },
       question: "What type of changes are you applying for?",
@@ -1646,9 +1600,7 @@ export const mockExpectedBOPSPayload = {
       ],
     },
     {
-      metadata: {
-        portal_name: "LDC - Proposed",
-      },
+      metadata: {},
       question: "Is the property a home?",
       responses: [
         {
@@ -1658,7 +1610,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "LDC - Proposed",
         auto_answered: true,
       },
       question: "What types of changes does the application relate to?",
@@ -1675,7 +1626,6 @@ export const mockExpectedBOPSPayload = {
             text: "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 Schedule 1, Part 2",
           },
         ],
-        portal_name: "LDC-P - Householder",
       },
       question: "How many homes does this application relate to?",
       responses: [
@@ -1686,7 +1636,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "LDC - Proposed",
         auto_answered: true,
       },
       question: "What alterations are being made to the building?",
@@ -1698,7 +1647,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "Fee Exemptions",
         auto_answered: true,
       },
       question: "Is the property a home?",
@@ -1710,7 +1658,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "Fee Exemptions",
         auto_answered: true,
       },
       question: "What works does the project involve?",
@@ -1727,7 +1674,6 @@ export const mockExpectedBOPSPayload = {
             text: "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012, Regulation 14UK Statutory Instruments 2012 No. 2920 Regulation 4, Equalities Act 2010, Section 6 Children Act 1989, Part 3",
           },
         ],
-        portal_name: "Fee Exemptions",
       },
       question:
         "Is the sole purpose of the project to support the needs of a disabled resident?",
@@ -1744,7 +1690,6 @@ export const mockExpectedBOPSPayload = {
             text: "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012, Regulation 9",
           },
         ],
-        portal_name: "Fee Exemptions",
       },
       question: "Is this application a resubmission?",
       responses: [
@@ -1755,7 +1700,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "Fee exemptions and adjustments",
         auto_answered: true,
       },
       question: "Does the application qualify for a disability exemption?",
@@ -1767,7 +1711,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "Fee exemptions and adjustments",
         auto_answered: true,
       },
       question: "Does the application qualify for a resubmission exemption?",
@@ -1784,7 +1727,6 @@ export const mockExpectedBOPSPayload = {
             text: "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 Chapter 2, Paragraph 3",
           },
         ],
-        portal_name: "Fee Reductions",
         auto_answered: true,
       },
       question: "Is the site a sports field?",
@@ -1801,7 +1743,6 @@ export const mockExpectedBOPSPayload = {
             text: "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 - Regulation 11",
           },
         ],
-        portal_name: "Fee Reductions",
         auto_answered: true,
       },
       question:
@@ -1819,7 +1760,6 @@ export const mockExpectedBOPSPayload = {
             text: "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 Chapter 2, Paragraph 10",
           },
         ],
-        portal_name: "Fee Reductions",
       },
       question:
         "Are you also submitting another proposal for the same site today?",
@@ -1831,7 +1771,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "Fee exemptions and adjustments",
         auto_answered: true,
       },
       question:
@@ -1849,7 +1788,6 @@ export const mockExpectedBOPSPayload = {
             text: "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 - Regulation 11",
           },
         ],
-        portal_name: "Fee exemptions and adjustments",
         auto_answered: true,
       },
       question:
@@ -1862,7 +1800,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "Fee exemptions and adjustments",
         auto_answered: true,
       },
       question:
@@ -1874,9 +1811,7 @@ export const mockExpectedBOPSPayload = {
       ],
     },
     {
-      metadata: {
-        portal_name: "pre-app-advice-check",
-      },
+      metadata: {},
       question:
         "Did you get any pre-application advice before making this application?",
       responses: [
@@ -1887,7 +1822,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "community-infrastructure-levy",
         auto_answered: true,
       },
       question: "What type of application is it?",
@@ -1899,7 +1833,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "CIL Liability check",
         auto_answered: true,
       },
       question: "What does the project involve?",
@@ -1914,7 +1847,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "apply-for-service-declarations",
         auto_answered: true,
       },
       question: "Which Local Planning authority is it?",
@@ -1925,9 +1857,7 @@ export const mockExpectedBOPSPayload = {
       ],
     },
     {
-      metadata: {
-        portal_name: "apply-for-service-declarations",
-      },
+      metadata: {},
       question: "Connections with London Borough of Lambeth",
       responses: [
         {
@@ -1936,9 +1866,7 @@ export const mockExpectedBOPSPayload = {
       ],
     },
     {
-      metadata: {
-        portal_name: "apply-for-service-declarations",
-      },
+      metadata: {},
       question: "I confirm that:",
       responses: [
         {
@@ -1949,7 +1877,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "uniform-translator",
         auto_answered: true,
       },
       question:
@@ -1962,7 +1889,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "uniform-translator",
         auto_answered: true,
       },
       question: "What type of application is it?",
@@ -1974,7 +1900,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "uniform-translator",
         auto_answered: true,
       },
       question: "What type of works are you applying about?",
@@ -1986,7 +1911,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "uniform-translator",
         auto_answered: true,
       },
       question: "What is the applicant's interest in the land?",
@@ -1998,7 +1922,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "uniform-translator",
         auto_answered: true,
       },
       question: "What is the user's role?",
@@ -2010,7 +1933,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "uniform-translator",
         auto_answered: true,
       },
       question: "What is the applicant's declared connections?",
@@ -2022,7 +1944,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "_root",
         auto_answered: true,
       },
       question: "Does the application qualify for a disability exemption?",
@@ -2034,7 +1955,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        portal_name: "_root",
         auto_answered: true,
       },
       question: "Does the application qualify for a resubmission exemption?",

--- a/src/export/bops/mocks/payload.ts
+++ b/src/export/bops/mocks/payload.ts
@@ -1121,7 +1121,6 @@ export const mockExpectedBOPSPayload = {
   proposal_details: [
     {
       metadata: {
-        
         auto_answered: true,
       },
       question: "Is the property in London Borough of Lambeth?",
@@ -1138,7 +1137,6 @@ export const mockExpectedBOPSPayload = {
             text: "Town and Country Planning Act 1990, Part 7, Section 191 &amp; Section 192",
           },
         ],
-        
       },
       question: "What are you applying about?",
       responses: [
@@ -1183,7 +1181,6 @@ export const mockExpectedBOPSPayload = {
     },
     {
       metadata: {
-        
         auto_answered: true,
       },
       question: "Is the property subject to any Article 4 directions?",

--- a/src/export/bops/model.ts
+++ b/src/export/bops/model.ts
@@ -88,7 +88,6 @@ export interface QuestionMetaData {
     url?: string;
     text?: string;
   }>;
-  portal_name?: string;
   section_name?: string;
   feedback?: string;
 }

--- a/src/export/bops/tests/flags.test.ts
+++ b/src/export/bops/tests/flags.test.ts
@@ -31,6 +31,7 @@ test("sends flag result despite no result component", () => {
     application_type: "lawfulness_certificate",
     proposal_details: [
       {
+        metadata: {},
         question: "which answer?",
         responses: [
           {
@@ -38,7 +39,6 @@ test("sends flag result despite no result component", () => {
             value: "prior",
           },
         ],
-        metadata: { portal_name: "_root" },
       },
     ],
     result: {
@@ -92,6 +92,7 @@ test("sends override description with flag result", () => {
     application_type: "lawfulness_certificate",
     proposal_details: [
       {
+        metadata: {},
         question: "which answer?",
         responses: [
           {
@@ -99,12 +100,11 @@ test("sends override description with flag result", () => {
             value: "permission",
           },
         ],
-        metadata: { portal_name: "_root" },
       },
       {
+        metadata: {},
         question: "do you want to override this decision?",
         responses: [{ value: "i don't agree" }],
-        metadata: { portal_name: "_root" },
       },
     ],
     result: {
@@ -148,9 +148,9 @@ test("sends 'no result' to BOPS when there is no collected flag", () => {
     application_type: "lawfulness_certificate",
     proposal_details: [
       {
+        metadata: {},
         question: "which answer?",
         responses: [{ value: "other" }],
-        metadata: { portal_name: "_root" },
       },
     ],
     result: {

--- a/src/export/bops/tests/proposalDetails.test.ts
+++ b/src/export/bops/tests/proposalDetails.test.ts
@@ -187,39 +187,39 @@ test("valid node types are serialized correctly for BOPS", () => {
     },
     proposalDetails: [
       {
+        metadata: {},
         question: "address question",
         responses: [{ value: "line1, line, town, county, postcode" }],
-        metadata: { portal_name: "_root" },
       },
       {
+        metadata: {},
         question: "checklist",
         responses: [{ value: "1" }, { value: "2" }],
-        metadata: { portal_name: "_root" },
       },
       {
+        metadata: {},
         question: "expandable checklist question",
         responses: [{ value: "c1" }, { value: "c2" }, { value: "c3" }],
-        metadata: { portal_name: "_root" },
       },
       {
+        metadata: {},
         question: "date question",
         responses: [{ value: "1999-01-01" }],
-        metadata: { portal_name: "_root" },
       },
       {
+        metadata: {},
         question: "number question",
         responses: [{ value: "500" }],
-        metadata: { portal_name: "_root" },
       },
       {
+        metadata: {},
         question: "regular question",
         responses: [{ value: "a1" }],
-        metadata: { portal_name: "_root" },
       },
       {
+        metadata: {},
         question: "text question",
         responses: [{ value: "testanswer" }],
-        metadata: { portal_name: "_root" },
       },
     ],
   };
@@ -248,39 +248,39 @@ test("removed nodes are skipped", () => {
     },
     proposalDetails: [
       {
+        metadata: {},
         question: "address question",
         responses: [{ value: "line1, line, town, county, postcode" }],
-        metadata: { portal_name: "_root" },
       },
       {
+        metadata: {},
         question: "checklist",
         responses: [{ value: "1" }, { value: "2" }],
-        metadata: { portal_name: "_root" },
       },
       {
+        metadata: {},
         question: "expandable checklist question",
         responses: [{ value: "c1" }, { value: "c2" }, { value: "c3" }],
-        metadata: { portal_name: "_root" },
       },
       {
+        metadata: {},
         question: "date question",
         responses: [{ value: "1999-01-01" }],
-        metadata: { portal_name: "_root" },
       },
       {
+        metadata: {},
         question: "number question",
         responses: [{ value: "500" }],
-        metadata: { portal_name: "_root" },
       },
       {
+        metadata: {},
         question: "regular question",
         responses: [{ value: "a1" }],
-        metadata: { portal_name: "_root" },
       },
       {
+        metadata: {},
         question: "text question",
         responses: [{ value: "testanswer" }],
-        metadata: { portal_name: "_root" },
       },
     ],
   };


### PR DESCRIPTION
BOPS devs confirmed they've made the switch over to `section_name` earlier today :heavy_check_mark:  
~optimistically queuing this up, but still waiting on go-ahead from BOPS devs here~: https://opendigitalplanning.slack.com/archives/C0182MVK4AW/p1688114717054409

`section_name` is now included in payloads for services with sections and offers a more meaningful grouping of questions than `portal_name` did, and is less expensive to compute which should be a small boost for processing submissions.