### PR TITLE
fix: map `proposal.description` to LDCP doc template

### DIFF
--- a/src/templates/docx/LDCPTemplate.ts
+++ b/src/templates/docx/LDCPTemplate.ts
@@ -180,7 +180,7 @@ export function LDCPTemplate(passport: Passport): Document {
           },
           {
             name: "If Yes to a, please give detailed description of all such operations (includes the need to describe any proposal to alter or create a new access, layout any new street, construct any associated hard-standings, means of enclosure or means of draining the land/buildings) and indicate on your plans (in the case of a proposed building the plan should indicate the precise siting and exact dimensions):",
-            value: "", // intentionally blank
+            value: get("proposal.description"),
           },
           {
             name: "b) Does the proposal consist of or include change to use of the land or building(s)?",

--- a/src/templates/mocks/exampleLDCP.json
+++ b/src/templates/mocks/exampleLDCP.json
@@ -56,7 +56,7 @@
     "uniform.personRole": ["Applicant"],
     "applicant.name.last": "Name",
     "applicant.name.first": "Test",
-    "proposal.description": "Test Case 1 8th December",
+    "proposal.description": "Description of Test Case 1 - 8th December",
     "proposal.projectType": ["alter.repair"],
     "applicant.siteContact": ["applicant"],
     "uniform.applicationTo": ["J0405"],


### PR DESCRIPTION
Per feedback here: https://trello.com/c/MYuIMAkf/2506-add-description-to-ldc-application-form

There isn't an equivalent field on LDCE. This field will _not_ be redacted.

**Before:**
![Screenshot from 2023-07-21 10-22-18](https://github.com/theopensystemslab/planx-core/assets/5132349/c3140873-ea67-494c-9bfc-63efa54e79fb)

**After:**
![Screenshot from 2023-07-21 10-22-50](https://github.com/theopensystemslab/planx-core/assets/5132349/3715476b-5c00-4632-a97f-38ab7709be36)