### PR TITLE
feat: Add team boundary argument to map and html creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@mui/material": "^5.14.5",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
+    "@types/geojson": "^7946.0.10",
     "docx": "^8.2.2",
     "eslint": "^8.47.0",
     "fast-xml-parser": "^4.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   '@mui/material':
     specifier: ^5.14.5
     version: 5.14.5(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@types/react@18.2.15)(react-dom@18.2.0)(react@18.2.0)
+  '@types/geojson':
+    specifier: ^7946.0.10
+    version: 7946.0.10
   ajv:
     specifier: ^8.12.0
     version: 8.12.0
@@ -1521,6 +1524,10 @@ packages:
     dependencies:
       '@babel/types': 7.22.5
     dev: true
+
+  /@types/geojson@7946.0.10:
+    resolution: {integrity: sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==}
+    dev: false
 
   /@types/glob@7.2.0:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}

--- a/src/templates/generateExamples.ts
+++ b/src/templates/generateExamples.ts
@@ -40,19 +40,19 @@ async function setUpExampleDir() {
 async function generateHTMLExamples() {
   const applicationHTML = generateApplicationHTML({
     planXExportData: exampleData.data,
-    teamBBox: buckinghamshireBoundary,
+    boundingBox: buckinghamshireBoundary,
   });
   writeFileSync(`./examples/application.html`, applicationHTML);
 
   const sectionHTML = generateApplicationHTML({
     planXExportData: exampleSectionData.data,
-    teamBBox: buckinghamshireBoundary,
+    boundingBox: buckinghamshireBoundary,
   });
   writeFileSync(`./examples/application_with_sections.html`, sectionHTML);
 
   const mapHTML = generateMapHTML({
     geojson: exampleData.geojson,
-    teamBBox: buckinghamshireBoundary,
+    boundingBox: buckinghamshireBoundary,
   });
   writeFileSync(`./examples/map.html`, mapHTML);
 }

--- a/src/templates/generateExamples.ts
+++ b/src/templates/generateExamples.ts
@@ -18,7 +18,7 @@ import exampleData from "./mocks/example.json";
 import exampleLDCEData from "./mocks/exampleLDCE.json";
 import exampleLDCPData from "./mocks/exampleLDCP.json";
 import exampleSectionData from "./mocks/exampleWithSections.json";
-import { ukBoundary } from "./mocks/ukBoundary";
+import { buckinghamshireBoundary } from "./mocks/ukBoundary";
 
 (async () => {
   try {
@@ -38,13 +38,22 @@ async function setUpExampleDir() {
 }
 
 async function generateHTMLExamples() {
-  const applicationHTML = generateApplicationHTML({ planXExportData: exampleData.data, teamBBox: ukBoundary });
+  const applicationHTML = generateApplicationHTML({
+    planXExportData: exampleData.data,
+    teamBBox: buckinghamshireBoundary,
+  });
   writeFileSync(`./examples/application.html`, applicationHTML);
 
-  const sectionHTML = generateApplicationHTML({ planXExportData: exampleSectionData.data, teamBBox: ukBoundary });
+  const sectionHTML = generateApplicationHTML({
+    planXExportData: exampleSectionData.data,
+    teamBBox: buckinghamshireBoundary,
+  });
   writeFileSync(`./examples/application_with_sections.html`, sectionHTML);
 
-  const mapHTML = generateMapHTML({ geojson: exampleData.geojson, teamBBox: ukBoundary });
+  const mapHTML = generateMapHTML({
+    geojson: exampleData.geojson,
+    teamBBox: buckinghamshireBoundary,
+  });
   writeFileSync(`./examples/map.html`, mapHTML);
 }
 

--- a/src/templates/generateExamples.ts
+++ b/src/templates/generateExamples.ts
@@ -18,6 +18,7 @@ import exampleData from "./mocks/example.json";
 import exampleLDCEData from "./mocks/exampleLDCE.json";
 import exampleLDCPData from "./mocks/exampleLDCP.json";
 import exampleSectionData from "./mocks/exampleWithSections.json";
+import { ukBoundary } from "./mocks/ukBoundary";
 
 (async () => {
   try {
@@ -37,13 +38,13 @@ async function setUpExampleDir() {
 }
 
 async function generateHTMLExamples() {
-  const applicationHTML = generateApplicationHTML(exampleData.data);
+  const applicationHTML = generateApplicationHTML({ planXExportData: exampleData.data, teamBBox: ukBoundary });
   writeFileSync(`./examples/application.html`, applicationHTML);
 
-  const sectionHTML = generateApplicationHTML(exampleSectionData.data);
+  const sectionHTML = generateApplicationHTML({ planXExportData: exampleSectionData.data, teamBBox: ukBoundary });
   writeFileSync(`./examples/application_with_sections.html`, sectionHTML);
 
-  const mapHTML = generateMapHTML(exampleData.geojson);
+  const mapHTML = generateMapHTML({ geojson: exampleData.geojson, teamBBox: ukBoundary });
   writeFileSync(`./examples/map.html`, mapHTML);
 }
 

--- a/src/templates/html/Main.tsx
+++ b/src/templates/html/Main.tsx
@@ -5,7 +5,7 @@ import React, { useState } from "react";
 import ReactDOM from "react-dom/client";
 
 import example from "../mocks/exampleWithSections.json";
-import { ukBoundary } from "../mocks/ukBoundary";
+import { buckinghamshireBoundary } from "../mocks/ukBoundary";
 import { ApplicationHTML } from "./application/ApplicationHTML";
 import { MapHTML } from "./map/MapHTML";
 
@@ -49,13 +49,16 @@ function TemplatesViewer(): JSX.Element {
         </Tabs>
       </Box>
       <TabPanel value={value} index={0}>
-        <MapHTML geojson={example.geojson} teamBBox={ukBoundary}/>
+        <MapHTML geojson={example.geojson} teamBBox={buckinghamshireBoundary} />
       </TabPanel>
       <TabPanel value={value} index={1}>
-        <ApplicationHTML data={example.data} teamBBox={ukBoundary} />
+        <ApplicationHTML
+          data={example.data}
+          teamBBox={buckinghamshireBoundary}
+        />
       </TabPanel>
       <TabPanel value={value} index={2}>
-        <ApplicationHTML data={[]} teamBBox={ukBoundary} />
+        <ApplicationHTML data={[]} teamBBox={buckinghamshireBoundary} />
       </TabPanel>
     </React.Fragment>
   );

--- a/src/templates/html/Main.tsx
+++ b/src/templates/html/Main.tsx
@@ -3,9 +3,11 @@ import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
 import React, { useState } from "react";
 import ReactDOM from "react-dom/client";
-import { MapHTML } from "./map/MapHTML";
-import { ApplicationHTML } from "./application/ApplicationHTML";
+
 import example from "../mocks/exampleWithSections.json";
+import { ukBoundary } from "../mocks/ukBoundary";
+import { ApplicationHTML } from "./application/ApplicationHTML";
+import { MapHTML } from "./map/MapHTML";
 
 interface TabPanelProps {
   children?: React.ReactNode;
@@ -47,13 +49,13 @@ function TemplatesViewer(): JSX.Element {
         </Tabs>
       </Box>
       <TabPanel value={value} index={0}>
-        <MapHTML geojson={example.geojson} />
+        <MapHTML geojson={example.geojson} teamBBox={ukBoundary}/>
       </TabPanel>
       <TabPanel value={value} index={1}>
-        <ApplicationHTML data={example.data} />
+        <ApplicationHTML data={example.data} teamBBox={ukBoundary} />
       </TabPanel>
       <TabPanel value={value} index={2}>
-        <ApplicationHTML data={[]} />
+        <ApplicationHTML data={[]} teamBBox={ukBoundary} />
       </TabPanel>
     </React.Fragment>
   );

--- a/src/templates/html/Main.tsx
+++ b/src/templates/html/Main.tsx
@@ -49,16 +49,19 @@ function TemplatesViewer(): JSX.Element {
         </Tabs>
       </Box>
       <TabPanel value={value} index={0}>
-        <MapHTML geojson={example.geojson} teamBBox={buckinghamshireBoundary} />
+        <MapHTML
+          geojson={example.geojson}
+          boundingBox={buckinghamshireBoundary}
+        />
       </TabPanel>
       <TabPanel value={value} index={1}>
         <ApplicationHTML
           data={example.data}
-          teamBBox={buckinghamshireBoundary}
+          boundingBox={buckinghamshireBoundary}
         />
       </TabPanel>
       <TabPanel value={value} index={2}>
-        <ApplicationHTML data={[]} teamBBox={buckinghamshireBoundary} />
+        <ApplicationHTML data={[]} boundingBox={buckinghamshireBoundary} />
       </TabPanel>
     </React.Fragment>
   );

--- a/src/templates/html/application/ApplicationHTML.tsx
+++ b/src/templates/html/application/ApplicationHTML.tsx
@@ -290,6 +290,7 @@ export function ApplicationHTML(props: {
                     showNorthArrow={true}
                     showScale={true}
                     useScalebarStyle={true}
+                    hideResetControl={true}
                     geojsonData={JSON.stringify(boundary)}
                     id="boundary-map"
                     showPrint={true}

--- a/src/templates/html/application/ApplicationHTML.tsx
+++ b/src/templates/html/application/ApplicationHTML.tsx
@@ -1,16 +1,17 @@
 import { css, Global } from "@emotion/react";
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
+import groupBy from "lodash.groupby";
 import prettyTitle from "lodash.startcase";
 import * as React from "react";
-import groupBy from "lodash.groupby";
+
+import type { PlanXExportData } from "../../../types";
 import {
   getToday,
   prettyQuestion,
   prettyResponse,
   validatePlanXExportData,
 } from "./helpers";
-import type { PlanXExportData } from "../../../types";
 
 function Highlights(props: { data: PlanXExportData[] }): JSX.Element {
   const siteAddress = props.data.find((d) => d.question === "site")?.responses;
@@ -204,7 +205,10 @@ function DataItem(props: { data: PlanXExportData }) {
   );
 }
 
-export function ApplicationHTML(props: { data: PlanXExportData[] }) {
+export function ApplicationHTML(props: {
+  data: PlanXExportData[];
+  teamBBox: GeoJSON.Feature;
+}) {
   // Pluck out some key questions & responses to show in special sections
   const applicationType: unknown = props.data.find(
     (d) => d.question === "application_type",
@@ -250,7 +254,7 @@ export function ApplicationHTML(props: { data: PlanXExportData[] }) {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <script src="https://cdn.jsdelivr.net/npm/@opensystemslab/map@0.7.2"></script>
+        <script src="https://cdn.jsdelivr.net/npm/@opensystemslab/map@0.7.5"></script>
         <title>{typeof documentTitle === "string" && documentTitle}</title>
         <link
           rel="stylesheet"
@@ -291,6 +295,7 @@ export function ApplicationHTML(props: { data: PlanXExportData[] }) {
                     geojsonData={JSON.stringify(boundary)}
                     id="boundary-map"
                     showPrint={true}
+                    clipGeojsonData={JSON.stringify(props.teamBBox)}
                   />
                 </Box>
               )}

--- a/src/templates/html/application/ApplicationHTML.tsx
+++ b/src/templates/html/application/ApplicationHTML.tsx
@@ -207,7 +207,7 @@ function DataItem(props: { data: PlanXExportData }) {
 
 export function ApplicationHTML(props: {
   data: PlanXExportData[];
-  teamBBox: GeoJSON.Feature;
+  boundingBox: GeoJSON.Feature;
 }) {
   // Pluck out some key questions & responses to show in special sections
   const applicationType: unknown = props.data.find(
@@ -293,7 +293,7 @@ export function ApplicationHTML(props: {
                     geojsonData={JSON.stringify(boundary)}
                     id="boundary-map"
                     showPrint={true}
-                    clipGeojsonData={JSON.stringify(props.teamBBox)}
+                    clipGeojsonData={JSON.stringify(props.boundingBox)}
                   />
                 </Box>
               )}

--- a/src/templates/html/application/ApplicationHTML.tsx
+++ b/src/templates/html/application/ApplicationHTML.tsx
@@ -287,11 +287,9 @@ export function ApplicationHTML(props: {
               {boundary && (
                 <Box sx={{ marginBottom: 1 }}>
                   <my-map
-                    staticMode={true}
                     showNorthArrow={true}
                     showScale={true}
                     useScalebarStyle={true}
-                    hideResetControl={true}
                     geojsonData={JSON.stringify(boundary)}
                     id="boundary-map"
                     showPrint={true}

--- a/src/templates/html/map/Map.tsx
+++ b/src/templates/html/map/Map.tsx
@@ -28,6 +28,7 @@ export default function Map(props: {
   return (
     <my-map
       showNorthArrow={true}
+      hideResetControl={true}
       showScale={true}
       geojsonData={JSON.stringify(props.boundary)}
       clipGeojsonData={JSON.stringify(props.clipGeojsonData)}

--- a/src/templates/html/map/Map.tsx
+++ b/src/templates/html/map/Map.tsx
@@ -16,11 +16,15 @@ declare global {
       showPrint?: boolean;
       useScalebarStyle?: boolean;
       staticMode?: boolean;
+      clipGeojsonData: string;
     }
   }
 }
 
-export default function Map(props: { boundary: object }) {
+export default function Map(props: {
+  boundary: object;
+  clipGeojsonData: GeoJSON.Feature;
+}) {
   return (
     <my-map
       staticMode={true}
@@ -28,6 +32,7 @@ export default function Map(props: { boundary: object }) {
       showScale={true}
       hideResetControl={true}
       geojsonData={JSON.stringify(props.boundary)}
+      clipGeojsonData={JSON.stringify(props.clipGeojsonData)}
     />
   );
 }

--- a/src/templates/html/map/Map.tsx
+++ b/src/templates/html/map/Map.tsx
@@ -10,7 +10,7 @@ declare global {
     interface MapProps {
       showNorthArrow: boolean;
       showScale: boolean;
-      hideResetControl: boolean;
+      hideResetControl?: boolean;
       geojsonData: string;
       id?: string;
       showPrint?: boolean;
@@ -27,10 +27,8 @@ export default function Map(props: {
 }) {
   return (
     <my-map
-      staticMode={true}
       showNorthArrow={true}
       showScale={true}
-      hideResetControl={true}
       geojsonData={JSON.stringify(props.boundary)}
       clipGeojsonData={JSON.stringify(props.clipGeojsonData)}
     />

--- a/src/templates/html/map/MapHTML.tsx
+++ b/src/templates/html/map/MapHTML.tsx
@@ -3,7 +3,10 @@ import * as React from "react";
 
 import Map from "./Map";
 
-export function MapHTML(props: { geojson: object; teamBBox: GeoJSON.Feature }) {
+export function MapHTML(props: {
+  geojson: object;
+  boundingBox: GeoJSON.Feature;
+}) {
   return (
     <html>
       <head>
@@ -15,7 +18,7 @@ export function MapHTML(props: { geojson: object; teamBBox: GeoJSON.Feature }) {
       <body>
         <Styles />
         <h1>Boundary</h1>
-        <Map boundary={props.geojson} clipGeojsonData={props.teamBBox} />
+        <Map boundary={props.geojson} clipGeojsonData={props.boundingBox} />
       </body>
     </html>
   );

--- a/src/templates/html/map/MapHTML.tsx
+++ b/src/templates/html/map/MapHTML.tsx
@@ -1,20 +1,21 @@
+import { css, Global } from "@emotion/react";
 import * as React from "react";
-import Map from "./Map";
-import { Global, css } from "@emotion/react";
 
-export function MapHTML(props: { geojson: object }) {
+import Map from "./Map";
+
+export function MapHTML(props: { geojson: object; teamBBox: GeoJSON.Feature }) {
   return (
     <html>
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <script src="https://cdn.jsdelivr.net/npm/@opensystemslab/map"></script>
+        <script src="https://cdn.jsdelivr.net/npm/@opensystemslab/map@0.7.5"></script>
         <title>PlanX Submission Boundary</title>
       </head>
       <body>
         <Styles />
         <h1>Boundary</h1>
-        <Map boundary={props.geojson} />
+        <Map boundary={props.geojson} clipGeojsonData={props.teamBBox} />
       </body>
     </html>
   );

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -68,16 +68,28 @@ export const TEMPLATES: Record<string, Template> = {
   },
 };
 
-export function generateApplicationHTML(
-  planXExportData: PlanXExportData[],
-): string {
+export function generateApplicationHTML({
+  planXExportData,
+  teamBBox,
+}: {
+  planXExportData: PlanXExportData[];
+  teamBBox: GeoJSON.Feature;
+}): string {
   return renderToStaticMarkup(
-    React.createElement(ApplicationHTML, { data: planXExportData }),
+    React.createElement(ApplicationHTML, { data: planXExportData, teamBBox }),
   );
 }
 
-export function generateMapHTML(geojson: object): string {
-  return renderToStaticMarkup(React.createElement(MapHTML, { geojson }));
+export function generateMapHTML({
+  geojson,
+  teamBBox,
+}: {
+  geojson: object;
+  teamBBox: GeoJSON.Feature;
+}): string {
+  return renderToStaticMarkup(
+    React.createElement(MapHTML, { geojson, teamBBox }),
+  );
 }
 
 export function generateDocxTemplateStream({

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -70,25 +70,28 @@ export const TEMPLATES: Record<string, Template> = {
 
 export function generateApplicationHTML({
   planXExportData,
-  teamBBox,
+  boundingBox,
 }: {
   planXExportData: PlanXExportData[];
-  teamBBox: GeoJSON.Feature;
+  boundingBox: GeoJSON.Feature;
 }): string {
   return renderToStaticMarkup(
-    React.createElement(ApplicationHTML, { data: planXExportData, teamBBox }),
+    React.createElement(ApplicationHTML, {
+      data: planXExportData,
+      boundingBox,
+    }),
   );
 }
 
 export function generateMapHTML({
   geojson,
-  teamBBox,
+  boundingBox,
 }: {
   geojson: object;
-  teamBBox: GeoJSON.Feature;
+  boundingBox: GeoJSON.Feature;
 }): string {
   return renderToStaticMarkup(
-    React.createElement(MapHTML, { geojson, teamBBox }),
+    React.createElement(MapHTML, { geojson, boundingBox }),
   );
 }
 

--- a/src/templates/mocks/ukBoundary.ts
+++ b/src/templates/mocks/ukBoundary.ts
@@ -1,0 +1,31 @@
+export const ukBoundary: GeoJSON.Feature = {
+  type: "Feature",
+  properties: {},
+  geometry: {
+    type: "Polygon",
+    coordinates: [
+      [
+        [
+          1.9134116,
+          49.528423
+        ],
+        [
+          1.9134116,
+          61.331151
+        ],
+        [
+          1.9134116,
+          61.331151
+        ],
+        [
+          -10.76418,
+          61.331151
+        ],
+        [
+          -10.76418,
+          49.528423
+        ]
+      ]
+    ]
+  }
+}

--- a/src/templates/mocks/ukBoundary.ts
+++ b/src/templates/mocks/ukBoundary.ts
@@ -1,31 +1,27 @@
-export const ukBoundary: GeoJSON.Feature = {
+export const buckinghamshireBoundary: GeoJSON.Feature = {
   type: "Feature",
-  properties: {},
   geometry: {
     type: "Polygon",
     coordinates: [
       [
-        [
-          1.9134116,
-          49.528423
-        ],
-        [
-          1.9134116,
-          61.331151
-        ],
-        [
-          1.9134116,
-          61.331151
-        ],
-        [
-          -10.76418,
-          61.331151
-        ],
-        [
-          -10.76418,
-          49.528423
-        ]
-      ]
-    ]
-  }
-}
+        [-1.140676, 51.485473],
+        [-1.140676, 52.081534],
+        [-0.476596, 52.081534],
+        [-0.476596, 51.485473],
+        [-1.140676, 51.485473],
+      ],
+    ],
+  },
+  properties: {
+    name: "Buckinghamshire",
+    entity: 8600318,
+    prefix: "statistical-geography",
+    dataset: "local-authority-district",
+    "end-date": "",
+    typology: "geography",
+    reference: "E06000060",
+    "entry-date": "2023-08-02",
+    "start-date": "",
+    "organisation-entity": "10",
+  },
+};


### PR DESCRIPTION
## What does this PR do?
 - Requires that an extent be passed to map and HTML templates
 - Uses Bucks as an example extent GeoJSON (see attached generated examples)
 - Re-enables map pan and zoom

📂  [Examples.zip](https://github.com/theopensystemslab/planx-core/files/12352683/Archive.zip)

Currently live on this environment - https://github.com/theopensystemslab/planx-new/pull/2099