### PR TITLE
feat: Add more `_destroyAll()` helpers

### DIFF
--- a/src/requests/flow.ts
+++ b/src/requests/flow.ts
@@ -26,8 +26,18 @@ export class FlowClient {
     return publishFlow(this.client, args);
   }
 
+  /**
+   * Only used in test environments
+   */
   async _destroy(flowId: string): Promise<boolean> {
     return _destroyFlow(this.client, flowId);
+  }
+
+  /**
+   * Only used in test environments
+   */
+  async _destroyAll(): Promise<boolean> {
+    return _destroyAllFlows(this.client);
   }
 
   async _destroyPublished(publishedFlowId: number): Promise<boolean> {
@@ -221,6 +231,20 @@ export async function _destroyFlow(
       { flowId },
     );
   return Boolean(response.delete_flows_by_pk?.id);
+}
+
+export async function _destroyAllFlows(
+  client: GraphQLClient,
+): Promise<boolean> {
+  const response: { deleteFlows: { affectedRows: string } } =
+    await client.request(gql`
+      mutation DestroyAllFlows {
+        deleteFlows: delete_flows(where: { id: { _is_null: false } }) {
+          affectedRows: affected_rows
+        }
+      }
+    `);
+  return Boolean(response.deleteFlows.affectedRows);
 }
 
 export async function _destroyPublishedFlow(

--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -44,8 +44,18 @@ export class TeamClient {
     return removeMember(this.client, args);
   }
 
+  /**
+   * Only used in test environments
+   */
   async _destroy(teamId: number): Promise<boolean> {
     return _destroyTeam(this.client, teamId);
+  }
+
+  /**
+   * Only used in test environments
+   */
+  async _destroyAll(): Promise<boolean> {
+    return _destroyAllTeams(this.client);
   }
 }
 
@@ -143,6 +153,20 @@ export async function _destroyTeam(
       { teamId },
     );
   return Boolean(response.delete_teams_by_pk?.id);
+}
+
+export async function _destroyAllTeams(
+  client: GraphQLClient,
+): Promise<boolean> {
+  const response: { deleteTeams: { affectedRows: number } } =
+    await client.request(gql`
+      mutation DestroyAllTeams {
+        deleteTeams: delete_teams(where: { id: { _is_null: false } }) {
+          affectedRows: affected_rows
+        }
+      }
+    `);
+  return Boolean(response.deleteTeams.affectedRows);
 }
 
 export async function upsertMember(

--- a/src/requests/user.ts
+++ b/src/requests/user.ts
@@ -21,8 +21,18 @@ export class UserClient {
     return createUser(this.client, args);
   }
 
+  /**
+   * Only used in test environments
+   */
   async _destroy(userId: number): Promise<boolean> {
     return _destroyUser(this.client, userId);
+  }
+
+  /**
+   * Only used in test environments
+   */
+  async _destroyAll(): Promise<boolean> {
+    return _destroyAllUsers(this.client);
   }
 
   async getByEmail(email: string): Promise<User | null> {
@@ -80,6 +90,20 @@ export async function _destroyUser(
       { userId },
     );
   return Boolean(response.delete_users_by_pk?.id);
+}
+
+export async function _destroyAllUsers(
+  client: GraphQLClient,
+): Promise<boolean> {
+  const response: { deleteUsers: { affectedRows: number } } =
+    await client.request(gql`
+      mutation DestroyAllUsers {
+        deleteUsers: delete_users(where: { id: { _is_null: false } }) {
+          affectedRows: affected_rows
+        }
+      }
+    `);
+  return Boolean(response.deleteUsers.affectedRows);
 }
 
 async function getByEmail(


### PR DESCRIPTION
To be implemented in https://github.com/theopensystemslab/planx-new/pull/2220 to help tear down permission-based tests.