### PR TITLE
fix: `node:assert` error causing failing builds in `planx-new`

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -10,7 +10,6 @@ export default {
     ],
   },
   testPathIgnorePatterns: ["dist/*", "tests/*"],
-  setupFilesAfterEnv: ["./jest.setup.js"],
   collectCoverage: true,
   coverageReporters: ["html", "lcov", "text-summary"],
   coverageDirectory: "./coverage",

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,2 +1,0 @@
-process.env.HASURA_GRAPHQL_ADMIN_SECRET = "👻";
-process.env.HASURA_GRAPHQL_URL = "👻";

--- a/src/requests/index.ts
+++ b/src/requests/index.ts
@@ -1,5 +1,3 @@
-import assert from "node:assert";
-
 import type { GraphQLClient } from "graphql-request";
 
 import { ExportClient } from "../export";
@@ -17,7 +15,6 @@ import { TeamClient } from "./team";
 import { UserClient } from "./user";
 
 const defaultURL = process.env.HASURA_GRAPHQL_URL!;
-assert(process.env.HASURA_GRAPHQL_URL);
 
 // declarative data access client
 export class CoreDomainClient {


### PR DESCRIPTION
When running `pnpm build` in `planx-new/editor.planx.uk` the following Webpack error was being thrown - 

```
Module build failed: UnhandledSchemeError: Reading from "node:assert" is not handled by plugins (Unhandled scheme).
```

The simple solution here is just to drop the `assert()` statements here which aren't essential.