### PR TITLE
fix: Profile `tsc`, fix `tsconfig.json`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "outDir": "dist"
   },
   "include": ["./src/*", "./src/**/*"],
-  "exclude": ["*.test.ts", "./src/**/mocks"]
+  "exclude": ["./src/**/*.test.ts", "./src/**/mocks"]
 }

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -18,5 +18,5 @@
     "outDir": "types"
   },
   "include": ["./src/types/*"],
-  "exclude": ["*.test.ts"]
+  "exclude": ["./src/**/*.test.ts", "./src/**/mocks"]
 }


### PR DESCRIPTION
## What's the problem?
Recent builds of `planx-new` are failing on Vultr due to JavaScript running out of heap memory when running the `pnpm build` step of `planx-core`. It's actually the TypeScript compilation step that's causing this to fall over. Recent changes in https://github.com/theopensystemslab/planx-core/pull/79 lead to this breaking change, notably - incorrectly glob patterns in the `exclude` list of `tsconfig.json` which means that very very large flows are being needlessly type-checked at build time.

## How was this identified?
Two massively helpful resource to problem solve this one - 
 - https://carlrannaberg.medium.com/overcoming-javascript-heap-out-of-memory-error-during-typescript-compilation-in-a-mui5-react-21396cc8a4e1
 - https://github.com/microsoft/TypeScript/wiki/Performance#writing-easy-to-compile-code

Running `pnpm dlx @typescript/analyze-trace ts-traces > ./ts-traces/analysis.txt` outputs the following file showing code "hotspots" from compilation -

```txt
Hot Spots
├─ Check file /users/dafyddllyr/code/planx-core/src/export/bops/mocks/flow.ts (1431ms)
│  └─ Check variable declaration from (line 4, char 14) to (line 151797, char 2) (1430ms)
│     └─ Check expression from (line 4, char 48) to (line 151797, char 2) (1138ms)
├─ Check file /users/dafyddllyr/code/planx-core/src/models/session/mocks/large-real-life-flow.ts (1384ms)
│  └─ Check variable declaration from (line 12, char 14) to (line 151805, char 2) (1384ms)
│     └─ Check expression from (line 12, char 32) to (line 151805, char 2) (1105ms)
└─ Check file /users/dafyddllyr/code/planx-core/src/templates/html/application/applicationhtml.tsx (859ms)
   └─ Check deferred node from (line 30, char 5) to (line 68, char 11) (587ms)
      └─ Check expression from (line 30, char 10) to (line 30, char 63) (460ms)

No duplicate packages found
```

This indicates that the above files are taking a long time to compile, and are not being picked up in the `exclude` list.

## Demo of changes

Running `tsc` with the `--extendedDiagnostics` flag generates the following output when building on `main` - 

#### Before - using over 1GB of memory
```sh
Files:                         1603
...
Memory used:               1077394K
...
Total time:                  12.73s
```

And now excluding these files - 

#### After - down to 355MB
```sh
Files:                        1563
...
Memory used:               355048K
..
Total time:                  4.73s
```

Spinning up a (small!) Pizza now pointing at this commit hash... https://github.com/theopensystemslab/planx-new/pull/2331 🍕 

Update: Pizza looks good, no installation issues.