### PR TITLE
fix: use Digital Planning Application v0.1.1 and fix validation errors

### DIFF
--- a/src/export/digitalPlanning/model.test.ts
+++ b/src/export/digitalPlanning/model.test.ts
@@ -19,7 +19,6 @@ const mockMetadataForSession = (teamSlug: string): SessionMetadata => ({
   flow: {
     id: "c06eebb7-6201-4bc0-9fe7-ec5d7a1c0797",
     slug: "apply-for-a-test-service",
-    publishedFlows: [{ id: 1 }],
     team: {
       name: teamSlug,
       slug: teamSlug,

--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -336,7 +336,6 @@ export class DigitalPlanning {
       },
     };
 
-    // @todo check if applies to Prior Approvals, if so add condition `&& !this.passport.data?.["application.type"][0].startsWith("pa")`
     if (this.passport.data?._address?.["property.region"]?.[0] === "London") {
       return {
         ...baseProperty,

--- a/src/export/digitalPlanning/schema/schema.json
+++ b/src/export/digitalPlanning/schema/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "@next",
+  "$id": "v0.1.1",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "definitions": {
@@ -701,7 +701,7 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Planning Permission",
+              "const": "Planning Permission - Full householder",
               "type": "string"
             },
             "value": {
@@ -716,7 +716,7 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Planning Permission - Retrospective",
+              "const": "Planning Permission - Full householder retrospective",
               "type": "string"
             },
             "value": {
@@ -1232,6 +1232,21 @@
             },
             "value": {
               "const": "proposal.document.designAndAccess",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Fire safety report",
+              "type": "string"
+            },
+            "value": {
+              "const": "proposal.document.fireSafety",
               "type": "string"
             }
           },
@@ -2071,14 +2086,11 @@
             "owner": {
               "type": "string"
             },
-            "publishedFlowId": {
-              "type": "number"
-            },
             "url": {
               "$ref": "#/definitions/URL"
             }
           },
-          "required": ["flowId", "publishedFlowId", "name", "owner", "url"],
+          "required": ["flowId", "name", "owner", "url"],
           "type": "object"
         },
         "session": {
@@ -4150,6 +4162,21 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Add a bay window to the rear of the building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.bayWindow.rear",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Remove a bay window",
               "type": "string"
             },
@@ -4170,6 +4197,186 @@
             },
             "value": {
               "const": "alter.boundary",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add a new fence, wall or gate",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.boundary.add",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add a new fence",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.boundary.add.fence",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add a new gate",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.boundary.add.gate",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add a new boundary wall",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.boundary.add.wall",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Repair a fence, wall or gate",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.boundary.repair",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Repair a fence",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.boundary.repair.fence",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Repair a gate",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.boundary.repair.gate",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Repair a wall",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.boundary.repair.wall",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Replace a fence, wall or gate",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.boundary.replace",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Replace a fence",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.boundary.replace.fence",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Replace a gate",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.boundary.replace.gate",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Replace a wall",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.boundary.replace.wall",
               "type": "string"
             }
           },
@@ -4315,6 +4522,51 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Install an aerial antennea",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.equipment.antennae.aerial",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Install a satellite dish",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.equipment.antennae.dish",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Install a barbeque",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.equipment.bbq",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Install a flue with a biomass burner",
               "type": "string"
             },
@@ -4365,6 +4617,66 @@
             },
             "value": {
               "const": "alter.equipment.heatPump",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Install an air heat pump",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.equipment.heatPump.air",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Install a ground heat pump",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.equipment.heatPump.ground",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Install a water heat pump",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.equipment.heatPump.water",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Install industrial equipment",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.equipment.industrial",
               "type": "string"
             }
           },
@@ -4480,11 +4792,131 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Paint the facade",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.facades.paint",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Change the material or colour of the external walls to the rear of the building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.facades.rear",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Change the cladding of the facade",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.facades.reclad",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Changes to a public road, pavement or path (including drop kerb)",
               "type": "string"
             },
             "value": {
               "const": "alter.highways",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Create a point of access to a highway",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.highways.access",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Create a point of access to an unclassified road",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.highways.access.unclassified",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Changes to a dropped kerb",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.highways.droppedKerb",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add a dropped kerb",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.highways.droppedKerb.add",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Remove a dropped kerb",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.highways.droppedKerb.remove",
               "type": "string"
             }
           },
@@ -4510,11 +4942,56 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Add or remove a residential lawn or garden",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.landscape.gardens",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Add or remove a pond",
               "type": "string"
             },
             "value": {
               "const": "alter.landscape.ponds",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Change a door or window opening",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.openings",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add a door or window opening",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.openings.add",
               "type": "string"
             }
           },
@@ -4540,6 +5017,51 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Add new doorways to the front of the building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.openings.add.door.front",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add new doorways to the rear of the building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.openings.add.door.rear",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add new doorways to the side of the building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.openings.add.door.side",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Add one or more new windows",
               "type": "string"
             },
@@ -4555,11 +5077,71 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Add doorways or new windows - 1.7m or higher",
+              "const": "Add new windows to the front of the building",
               "type": "string"
             },
             "value": {
-              "const": "alter.openings.add.windows.high",
+              "const": "alter.openings.add.window.front",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add new windows 1.7m up or higher",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.openings.add.window.high",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add new windows to the rear of the building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.openings.add.window.rear",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add new shutters to windows",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.openings.add.window.shutters",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add new windows to the side of the building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.openings.add.window.side",
               "type": "string"
             }
           },
@@ -4690,6 +5272,21 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Install pipes",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.pipes",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Remove part of a building (such as a decorative feature)",
               "type": "string"
             },
@@ -4720,6 +5317,21 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Remove a deck",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.remove.deck",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Remove energy equipment",
               "type": "string"
             },
@@ -4735,11 +5347,86 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Remove part of a facade",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.remove.facade",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Remove a soil pipe",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.remove.soilPipe",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Remove a hard surface",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.remove.surface",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Repair windows or doors",
               "type": "string"
             },
             "value": {
               "const": "alter.repair",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Repair doors",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.repair.doors",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Repair windows",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.repair.windows",
               "type": "string"
             }
           },
@@ -4825,11 +5512,41 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Change the roof",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.roof",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Replace or change the roof materials",
               "type": "string"
             },
             "value": {
               "const": "alter.roof.materials",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add or change a roof parapet",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.roof.parapet",
               "type": "string"
             }
           },
@@ -4930,6 +5647,21 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Add an advert or sign",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.sign",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Add or replace a soil pipe",
               "type": "string"
             },
@@ -4995,6 +5727,36 @@
             },
             "value": {
               "const": "alter.swimmingPool",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Install an indoor swimming pool",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.swimmingPool.indoor",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Install an outdoor swimming pool",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter.swimmingPool.outdoor",
               "type": "string"
             }
           },
@@ -5280,6 +6042,36 @@
             },
             "value": {
               "const": "extend.basement",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Enlarge a basement",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.basement.extend",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add a lightwell",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.basement.lightwell",
               "type": "string"
             }
           },
@@ -5605,11 +6397,86 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Add a porch to the front of the building",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.porch.front",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add a porch to the rear of the building",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.porch.rear",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add a porch to the side of the building",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.porch.side",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Add a rear or side extension (or conservatory)",
               "type": "string"
             },
             "value": {
               "const": "extend.rear",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add a rear extension",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.rear.rear",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add a side extension",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.rear.side",
               "type": "string"
             }
           },
@@ -5635,11 +6502,131 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Add roof dormers",
+              "const": "Add a roof dormer",
               "type": "string"
             },
             "value": {
               "const": "extend.roof.dormer",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add a roof dormer to the front of the building",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.roof.dormer.front",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add a roof dormer to the front and rear of the building",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.roof.dormer.frontAndRear",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add a mansard roof",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.roof.dormer.mansard",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add a roof dormer to the rear of the building",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.roof.dormer.rear",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add a roof dormer to the side of the building",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.roof.dormer.side",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Hip-to-gable roof enlargement",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.roof.hipToGable",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add one or more new storeys",
+              "type": "string"
+            },
+            "value": {
+              "const": "exend.roof.newStorey",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Add an upper storey extension",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend.upperStorey",
               "type": "string"
             }
           },
@@ -5655,6 +6642,51 @@
             },
             "value": {
               "const": "internal",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Alter internal doors",
+              "type": "string"
+            },
+            "value": {
+              "const": "internal.doorways",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Alter internal finishes",
+              "type": "string"
+            },
+            "value": {
+              "const": "internal.finishes",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Alter internal floors",
+              "type": "string"
+            },
+            "value": {
+              "const": "internal.floors",
               "type": "string"
             }
           },
@@ -5695,6 +6727,51 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Alter internal staircases",
+              "type": "string"
+            },
+            "value": {
+              "const": "internal.staircases",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Alter internal walls",
+              "type": "string"
+            },
+            "value": {
+              "const": "internal.walls",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Alter internal window openings",
+              "type": "string"
+            },
+            "value": {
+              "const": "internal.windows.openings",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Another type of building",
               "type": "string"
             },
@@ -5725,6 +6802,66 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Agricultural buildings - glass house",
+              "type": "string"
+            },
+            "value": {
+              "const": "new.agriculture.glassHouse",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Agricultural buildings - mining",
+              "type": "string"
+            },
+            "value": {
+              "const": "new.agriculture.mining",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Agricultural buildings - pigs",
+              "type": "string"
+            },
+            "value": {
+              "const": "new.agriculture.pigs",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Agricultural buildings - poultry",
+              "type": "string"
+            },
+            "value": {
+              "const": "new agriculture.poultry",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Install click and collect facilities",
               "type": "string"
             },
@@ -5745,6 +6882,36 @@
             },
             "value": {
               "const": "new.dwelling",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "New flats",
+              "type": "string"
+            },
+            "value": {
+              "const": "new.dwelling.flat",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "New houses",
+              "type": "string"
+            },
+            "value": {
+              "const": "new.dwelling.house",
               "type": "string"
             }
           },

--- a/src/export/digitalPlanning/schema/types.d.ts
+++ b/src/export/digitalPlanning/schema/types.d.ts
@@ -156,11 +156,11 @@ export type ApplicationType =
       value: "pp";
     }
   | {
-      description: "Planning Permission";
+      description: "Planning Permission - Full householder";
       value: "pp.full.householder";
     }
   | {
-      description: "Planning Permission - Retrospective";
+      description: "Planning Permission - Full householder retrospective";
       value: "pp.full.householder.retro";
     };
 /**
@@ -2791,12 +2791,64 @@ export type ProjectType =
       value: "alter.bayWindow.add";
     }
   | {
+      description: "Add a bay window to the rear of the building";
+      value: "alter.bayWindow.rear";
+    }
+  | {
       description: "Remove a bay window";
       value: "alter.bayWindow.remove";
     }
   | {
       description: "Changes to a fence, wall or gate";
       value: "alter.boundary";
+    }
+  | {
+      description: "Add a new fence, wall or gate";
+      value: "alter.boundary.add";
+    }
+  | {
+      description: "Add a new fence";
+      value: "alter.boundary.add.fence";
+    }
+  | {
+      description: "Add a new gate";
+      value: "alter.boundary.add.gate";
+    }
+  | {
+      description: "Add a new boundary wall";
+      value: "alter.boundary.add.wall";
+    }
+  | {
+      description: "Repair a fence, wall or gate";
+      value: "alter.boundary.repair";
+    }
+  | {
+      description: "Repair a fence";
+      value: "alter.boundary.repair.fence";
+    }
+  | {
+      description: "Repair a gate";
+      value: "alter.boundary.repair.gate";
+    }
+  | {
+      description: "Repair a wall";
+      value: "alter.boundary.repair.wall";
+    }
+  | {
+      description: "Replace a fence, wall or gate";
+      value: "alter.boundary.replace";
+    }
+  | {
+      description: "Replace a fence";
+      value: "alter.boundary.replace.fence";
+    }
+  | {
+      description: "Replace a gate";
+      value: "alter.boundary.replace.gate";
+    }
+  | {
+      description: "Replace a wall";
+      value: "alter.boundary.replace.wall";
     }
   | {
       description: "Install underground cables";
@@ -2835,6 +2887,18 @@ export type ProjectType =
       value: "alter.equipment.antennae";
     }
   | {
+      description: "Install an aerial antennea";
+      value: "alter.equipment.antennae.aerial";
+    }
+  | {
+      description: "Install a satellite dish";
+      value: "alter.equipment.antennae.dish";
+    }
+  | {
+      description: "Install a barbeque";
+      value: "alter.equipment.bbq";
+    }
+  | {
       description: "Install a flue with a biomass burner";
       value: "alter.equipment.biomass";
     }
@@ -2849,6 +2913,22 @@ export type ProjectType =
   | {
       description: "Install a heat pump";
       value: "alter.equipment.heatPump";
+    }
+  | {
+      description: "Install an air heat pump";
+      value: "alter.equipment.heatPump.air";
+    }
+  | {
+      description: "Install a ground heat pump";
+      value: "alter.equipment.heatPump.ground";
+    }
+  | {
+      description: "Install a water heat pump";
+      value: "alter.equipment.heatPump.water";
+    }
+  | {
+      description: "Install industrial equipment";
+      value: "alter.equipment.industrial";
     }
   | {
       description: "Install outdoor lights";
@@ -2879,28 +2959,100 @@ export type ProjectType =
       value: "alter.facades";
     }
   | {
+      description: "Paint the facade";
+      value: "alter.facades.paint";
+    }
+  | {
+      description: "Change the material or colour of the external walls to the rear of the building";
+      value: "alter.facades.rear";
+    }
+  | {
+      description: "Change the cladding of the facade";
+      value: "alter.facades.reclad";
+    }
+  | {
       description: "Changes to a public road, pavement or path (including drop kerb)";
       value: "alter.highways";
+    }
+  | {
+      description: "Create a point of access to a highway";
+      value: "alter.highways.access";
+    }
+  | {
+      description: "Create a point of access to an unclassified road";
+      value: "alter.highways.access.unclassified";
+    }
+  | {
+      description: "Changes to a dropped kerb";
+      value: "alter.highways.droppedKerb";
+    }
+  | {
+      description: "Add a dropped kerb";
+      value: "alter.highways.droppedKerb.add";
+    }
+  | {
+      description: "Remove a dropped kerb";
+      value: "alter.highways.droppedKerb.remove";
     }
   | {
       description: "Landscaping works";
       value: "alter.landscape";
     }
   | {
+      description: "Add or remove a residential lawn or garden";
+      value: "alter.landscape.gardens";
+    }
+  | {
       description: "Add or remove a pond";
       value: "alter.landscape.ponds";
+    }
+  | {
+      description: "Change a door or window opening";
+      value: "alter.openings";
+    }
+  | {
+      description: "Add a door or window opening";
+      value: "alter.openings.add";
     }
   | {
       description: "Add one or more new doorways";
       value: "alter.openings.add.door";
     }
   | {
+      description: "Add new doorways to the front of the building";
+      value: "alter.openings.add.door.front";
+    }
+  | {
+      description: "Add new doorways to the rear of the building";
+      value: "alter.openings.add.door.rear";
+    }
+  | {
+      description: "Add new doorways to the side of the building";
+      value: "alter.openings.add.door.side";
+    }
+  | {
       description: "Add one or more new windows";
       value: "alter.openings.add.window";
     }
   | {
-      description: "Add doorways or new windows - 1.7m or higher";
-      value: "alter.openings.add.windows.high";
+      description: "Add new windows to the front of the building";
+      value: "alter.openings.add.window.front";
+    }
+  | {
+      description: "Add new windows 1.7m up or higher";
+      value: "alter.openings.add.window.high";
+    }
+  | {
+      description: "Add new windows to the rear of the building";
+      value: "alter.openings.add.window.rear";
+    }
+  | {
+      description: "Add new shutters to windows";
+      value: "alter.openings.add.window.shutters";
+    }
+  | {
+      description: "Add new windows to the side of the building";
+      value: "alter.openings.add.window.side";
     }
   | {
       description: "Change the size of doorways or windows";
@@ -2935,6 +3087,10 @@ export type ProjectType =
       value: "alter.openings.remove";
     }
   | {
+      description: "Install pipes";
+      value: "alter.pipes";
+    }
+  | {
       description: "Remove part of a building (such as a decorative feature)";
       value: "alter.remove";
     }
@@ -2943,12 +3099,36 @@ export type ProjectType =
       value: "alter.remove.chimney";
     }
   | {
+      description: "Remove a deck";
+      value: "alter.remove.deck";
+    }
+  | {
       description: "Remove energy equipment";
       value: "alter.remove.equipment";
     }
   | {
+      description: "Remove part of a facade";
+      value: "alter.remove.facade";
+    }
+  | {
+      description: "Remove a soil pipe";
+      value: "alter.remove.soilPipe";
+    }
+  | {
+      description: "Remove a hard surface";
+      value: "alter.remove.surface";
+    }
+  | {
       description: "Repair windows or doors";
       value: "alter.repair";
+    }
+  | {
+      description: "Repair doors";
+      value: "alter.repair.doors";
+    }
+  | {
+      description: "Repair windows";
+      value: "alter.repair.windows";
     }
   | {
       description: "Replace windows or doors";
@@ -2971,8 +3151,16 @@ export type ProjectType =
       value: "alter.replace.windowsToWindows";
     }
   | {
+      description: "Change the roof";
+      value: "alter.roof";
+    }
+  | {
       description: "Replace or change the roof materials";
       value: "alter.roof.materials";
+    }
+  | {
+      description: "Add or change a roof parapet";
+      value: "alter.roof.parapet";
     }
   | {
       description: "Add a roof terrace";
@@ -2999,6 +3187,10 @@ export type ProjectType =
       value: "alter.shutters";
     }
   | {
+      description: "Add an advert or sign";
+      value: "alter.sign";
+    }
+  | {
       description: "Add or replace a soil pipe";
       value: "alter.soilPipes";
     }
@@ -3017,6 +3209,14 @@ export type ProjectType =
   | {
       description: "Install a swimming pool";
       value: "alter.swimmingPool";
+    }
+  | {
+      description: "Install an indoor swimming pool";
+      value: "alter.swimmingPool.indoor";
+    }
+  | {
+      description: "Install an outdoor swimming pool";
+      value: "alter.swimmingPool.outdoor";
     }
   | {
       description: "Changes to trees or hedges";
@@ -3093,6 +3293,14 @@ export type ProjectType =
   | {
       description: "Add a basement extension";
       value: "extend.basement";
+    }
+  | {
+      description: "Enlarge a basement";
+      value: "extend.basement.extend";
+    }
+  | {
+      description: "Add a lightwell";
+      value: "extend.basement.lightwell";
     }
   | {
       description: "Add a front extension";
@@ -3179,20 +3387,84 @@ export type ProjectType =
       value: "extend.porch";
     }
   | {
+      description: "Add a porch to the front of the building";
+      value: "extend.porch.front";
+    }
+  | {
+      description: "Add a porch to the rear of the building";
+      value: "extend.porch.rear";
+    }
+  | {
+      description: "Add a porch to the side of the building";
+      value: "extend.porch.side";
+    }
+  | {
       description: "Add a rear or side extension (or conservatory)";
       value: "extend.rear";
+    }
+  | {
+      description: "Add a rear extension";
+      value: "extend.rear.rear";
+    }
+  | {
+      description: "Add a side extension";
+      value: "extend.rear.side";
     }
   | {
       description: "Add a roof extension";
       value: "extend.roof";
     }
   | {
-      description: "Add roof dormers";
+      description: "Add a roof dormer";
       value: "extend.roof.dormer";
+    }
+  | {
+      description: "Add a roof dormer to the front of the building";
+      value: "extend.roof.dormer.front";
+    }
+  | {
+      description: "Add a roof dormer to the front and rear of the building";
+      value: "extend.roof.dormer.frontAndRear";
+    }
+  | {
+      description: "Add a mansard roof";
+      value: "extend.roof.dormer.mansard";
+    }
+  | {
+      description: "Add a roof dormer to the rear of the building";
+      value: "extend.roof.dormer.rear";
+    }
+  | {
+      description: "Add a roof dormer to the side of the building";
+      value: "extend.roof.dormer.side";
+    }
+  | {
+      description: "Hip-to-gable roof enlargement";
+      value: "extend.roof.hipToGable";
+    }
+  | {
+      description: "Add one or more new storeys";
+      value: "exend.roof.newStorey";
+    }
+  | {
+      description: "Add an upper storey extension";
+      value: "extend.upperStorey";
     }
   | {
       description: "Internal building works, such as change the internal layout";
       value: "internal";
+    }
+  | {
+      description: "Alter internal doors";
+      value: "internal.doorways";
+    }
+  | {
+      description: "Alter internal finishes";
+      value: "internal.finishes";
+    }
+  | {
+      description: "Alter internal floors";
+      value: "internal.floors";
     }
   | {
       description: "Convert a loft";
@@ -3203,6 +3475,18 @@ export type ProjectType =
       value: "internal.mezzanine";
     }
   | {
+      description: "Alter internal staircases";
+      value: "internal.staircases";
+    }
+  | {
+      description: "Alter internal walls";
+      value: "internal.walls";
+    }
+  | {
+      description: "Alter internal window openings";
+      value: "internal.windows.openings";
+    }
+  | {
       description: "Another type of building";
       value: "new";
     }
@@ -3211,12 +3495,36 @@ export type ProjectType =
       value: "new.agriculture";
     }
   | {
+      description: "Agricultural buildings - glass house";
+      value: "new.agriculture.glassHouse";
+    }
+  | {
+      description: "Agricultural buildings - mining";
+      value: "new.agriculture.mining";
+    }
+  | {
+      description: "Agricultural buildings - pigs";
+      value: "new.agriculture.pigs";
+    }
+  | {
+      description: "Agricultural buildings - poultry";
+      value: "new agriculture.poultry";
+    }
+  | {
       description: "Install click and collect facilities";
       value: "new.clickCollect";
     }
   | {
       description: "New, self-contained dwelling";
       value: "new.dwelling";
+    }
+  | {
+      description: "New flats";
+      value: "new.dwelling.flat";
+    }
+  | {
+      description: "New houses";
+      value: "new.dwelling.house";
     }
   | {
       description: "Build new forestry buildings";
@@ -3357,6 +3665,10 @@ export type FileType =
   | {
       description: "Design and Access Statement";
       value: "proposal.document.designAndAccess";
+    }
+  | {
+      description: "Fire safety report";
+      value: "proposal.document.fireSafety";
     }
   | {
       description: "Flood risk assessment";
@@ -3993,7 +4305,6 @@ export interface DigitalPlanningMetadata {
   flowId: UUID;
   name: string;
   owner: string;
-  publishedFlowId: number;
   url: URL;
 }
 export interface QuestionAndResponses {

--- a/src/requests/session.ts
+++ b/src/requests/session.ts
@@ -160,12 +160,6 @@ export async function getSessionMetadata(
             flow {
               id
               slug
-              publishedFlows: published_flows(
-                order_by: { created_at: desc }
-                limit: 1
-              ) {
-                id
-              }
               team {
                 name
                 slug

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -63,7 +63,6 @@ export type SessionMetadata = {
   flow: {
     id: string;
     slug: string;
-    publishedFlows: Array<Record<"id", number>>;
     team: {
       name: string;
       slug: string;


### PR DESCRIPTION
- Copy over release v0.1.1 of the Digital Planning Application schema and auto generate types
  - Update mapping to remove `metadata.service.publishedFlowId` 
- Checking all production submissions in October 2023 to see if they validate or not and fixing errors:

| `sessionId` | Type | Validates | Notes
|---|---|---|---|
| `d7cf2da2-fb4c-4930-841d-33e4ed23d905`  | Bucks LDC  | :heavy_check_mark:   | | 
| `fe6fa607-ee22-4e05-b4e0-382d5d00b9e6`  | Gloucester PP  | :heavy_check_mark:  | |
| `2e3cabab-633d-4869-a5de-0752c612ac14` | Gloucester PP | :heavy_check_mark: | |
| `faa32d08-246d-4510-97ef-689abb2b36dc`  | Southwark LDC | :x: | Custom flag & result text raises enum type error |
| `97c4fe80-2862-4e7e-9e0c-3786ed31a5d6` | Southwark LDC | :x: | Uploaded `proposal.drawing.locationPlan` instead of drawing; our schema incorrectly marks boundary as required |
| `890ccf44-4c0f-473d-ad7b-f63cae24b19e` | Lambeth LDC | :x: | Passport mapping was using `planx_value` rather than `property.type`, raising enum type error when OS returns undefined |
| `f4cc3953-bfb1-47d1-a9ce-955a6bd6b549` | Lambeth LDC | :x: | Passport mapping was using `planx_value` rather than `property.type`, raising enum type error when OS returns undefined | 
| `f4c23bee-f0a4-4915-8e85-3307429a8292` | Lambeth LDC | :x: | `applicant.interest` = "other" which we haven't accounted for in our enum type |
| `878215a1-ddad-49e8-8040-f52d00c228b3` | Lambeth LDC | :x: | File type `proposal.photograph.evidence` was provided which we haven't accounted for in our enum type |

Relies on some fixes here: https://github.com/theopensystemslab/digital-planning-data-schemas/pull/58 (not included in v0.1.1 release)