### PR TITLE
chore: More type tightening

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,7 +9,7 @@ export default {
       },
     ],
   },
-  testPathIgnorePatterns: ["dist/*", "tests/*"],
+  testPathIgnorePatterns: ["dist/*"],
   collectCoverage: true,
   coverageReporters: ["html", "lcov", "text-summary"],
   coverageDirectory: "./coverage",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "rimraf ./types ./dist && tsc --project ./tsconfig.types.json && tsc && pnpm copy-json-schema",
+    "build": "rimraf ./types ./dist && tsc --project ./tsconfig.types.json && tsc --project ./tsconfig.build.json && pnpm copy-json-schema",
     "examples": "rimraf ./examples && ts-node ./src/templates/generateExamples.ts",
     "lint": "eslint 'src/**/*.{js,ts}' && prettier -c src/**/*",
     "lint:fix": "eslint --fix 'src/**/*.{js,ts}' && prettier -w src/**/*",

--- a/src/export/bops/tests/addressInput.test.ts
+++ b/src/export/bops/tests/addressInput.test.ts
@@ -54,8 +54,10 @@ describe("AddressInput details are set correctly based on the breadcrumbs", () =
       (detail) => detail.question === "What's your address",
     )?.[0];
 
-    expect(addressInputItem?.responses[0]?.["value"]).toEqual(
-      "10 Main Street, Apt 1, Southwark, London, SE5 0HU, UK",
+    expect(addressInputItem?.responses[0]).toEqual(
+      expect.objectContaining({
+        value: "10 Main Street, Apt 1, Southwark, London, SE5 0HU, UK",
+      }),
     );
   });
 
@@ -84,8 +86,10 @@ describe("AddressInput details are set correctly based on the breadcrumbs", () =
       (detail) => detail.question === "What's your address",
     )?.[0];
 
-    expect(addressInputItem?.responses[0]?.["value"]).toEqual(
-      "10 Main Street, Southwark, SE5 0HU",
+    expect(addressInputItem?.responses[0]).toEqual(
+      expect.objectContaining({
+        value: "10 Main Street, Southwark, SE5 0HU",
+      }),
     );
   });
 });

--- a/src/export/bops/tests/contactInput.test.ts
+++ b/src/export/bops/tests/contactInput.test.ts
@@ -70,8 +70,10 @@ describe("ContactInput details are set correctly based on the breadcrumbs", () =
       (detail) => detail.question === "Your contact details",
     )?.[0];
 
-    expect(contactInputItem?.responses[0]?.["value"]).toEqual(
-      "Ms Jane Doe Open Systems Lab 0123456789 test@test.com",
+    expect(contactInputItem?.responses[0]).toEqual(
+      expect.objectContaining({
+        value: "Ms Jane Doe Open Systems Lab 0123456789 test@test.com",
+      }),
     );
   });
 
@@ -104,8 +106,10 @@ describe("ContactInput details are set correctly based on the breadcrumbs", () =
       (detail) => detail.question === "Your contact details",
     )?.[0];
 
-    expect(contactInputItem?.responses[0]?.["value"]).toEqual(
-      "Jane Doe 0123456789 test@test.com",
+    expect(contactInputItem?.responses[0]).toEqual(
+      expect.objectContaining({
+        value: "Jane Doe 0123456789 test@test.com",
+      }),
     );
   });
 });

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -12,11 +12,10 @@
     "skipLibCheck": true,
     "jsx": "react",
     "strict": true,
-    "rootDir": "./src/types",
+    "rootDir": "./src",
     "declaration": true,
-    "declarationDir": "types",
-    "outDir": "types"
+    "outDir": "dist"
   },
-  "include": ["./src/types/*"],
+  "include": ["./src/*", "./src/**/*"],
   "exclude": ["./src/**/*.test.ts", "./src/**/mocks"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "outDir": "dist"
   },
   "include": ["./src/*", "./src/**/*"],
-  "exclude": ["./src/**/*.test.ts", "./src/**/mocks"]
+  "exclude": ["./src/**/mocks"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,4 @@
     "outDir": "dist"
   },
   "include": ["./src/*", "./src/**/*"],
-  "exclude": ["./src/**/mocks"]
 }

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -18,5 +18,5 @@
     "outDir": "types"
   },
   "include": ["./src/types/*"],
-  "exclude": ["./src/**/*.test.ts", "./src/**/mocks"]
+  "exclude": ["./src/**/mocks"]
 }


### PR DESCRIPTION
## What does this PR do?
- Follow on from https://github.com/theopensystemslab/planx-core/pull/78
- Removes all `implicitAny`s apart from those in `src/export/digitalPlanning/model.ts`

### Next steps
 - Write `Passport.get()` method to replace the placeholder `Passport.generic()` (see https://github.com/theopensystemslab/planx-core/pull/78#discussion_r1363887300)
 - Test TS compilation on Pizza
 - Rebase / merge / cherry-pick https://github.com/theopensystemslab/planx-core/pull/68 to move things forward there