### PR TITLE
chore: Lowercase email on user creation

### DIFF
--- a/src/requests/user.ts
+++ b/src/requests/user.ts
@@ -78,7 +78,7 @@ export async function createUser(
     {
       first_name: args.firstName,
       last_name: args.lastName,
-      email: args.email,
+      email: args.email.toLowerCase(),
       is_platform_admin: args.isPlatformAdmin,
     },
   );


### PR DESCRIPTION
There's a few ways to solve this one, but this feels like a good balance of visibility and pragmaticm. 

For reference - we handle this with a DB trigger for `lowcal_sessions`

I've updated any email records on production to be all lowercase.