### PR TITLE
feat: update digital planning data schema mappings

### DIFF
--- a/src/export/digitalPlanning/schema/schema.json
+++ b/src/export/digitalPlanning/schema/schema.json
@@ -1,12 +1,12 @@
 {
-  "$id": "v0.1.1",
+  "$id": "@next",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "definitions": {
-    "AddressInput": {
-      "$id": "#AddressInput",
+    "Address": {
+      "$id": "#Address",
       "additionalProperties": false,
-      "description": "Address information for a personal contact not necessarily associated with the site",
+      "description": "Address information for a person associated with this application not at the property address",
       "properties": {
         "country": {
           "type": "string"
@@ -33,7 +33,7 @@
     "Agent": {
       "$id": "#Agent",
       "additionalProperties": false,
-      "description": "Information about the user who completed the application on behalf of someone else",
+      "description": "Information about the agent or proxy who completed the application on behalf of someone else",
       "properties": {
         "address": {
           "$ref": "#/definitions/UserAddress"
@@ -42,60 +42,95 @@
           "additionalProperties": false,
           "properties": {
             "address": {
-              "$ref": "#/definitions/AddressInput"
+              "$ref": "#/definitions/Address"
             },
-            "contact": {
-              "$ref": "#/definitions/UserContact"
+            "company": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": ["name"],
+              "type": "object"
+            },
+            "email": {
+              "$ref": "#/definitions/Email"
+            },
+            "name": {
+              "additionalProperties": false,
+              "properties": {
+                "first": {
+                  "type": "string"
+                },
+                "last": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              },
+              "required": ["first", "last"],
+              "type": "object"
+            },
+            "phone": {
+              "additionalProperties": false,
+              "properties": {
+                "primary": {
+                  "type": "string"
+                }
+              },
+              "required": ["primary"],
+              "type": "object"
             }
           },
-          "required": ["contact", "address"],
+          "required": ["name", "email", "phone", "address"],
           "type": "object"
         },
-        "contact": {
-          "$ref": "#/definitions/UserContact"
-        },
-        "interest": {
-          "enum": ["owner.sole", "owner.co", "tenant", "occupier"],
-          "type": "string"
-        },
-        "ownership": {
+        "company": {
           "additionalProperties": false,
           "properties": {
-            "certificate": {
-              "enum": ["a", "b", "c", "d"],
+            "name": {
               "type": "string"
-            },
-            "noticeGiven": {
-              "type": "boolean"
-            },
-            "owners": {
-              "items": {
-                "additionalProperties": false,
-                "properties": {
-                  "address": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/definitions/AddressInput"
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ]
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "noticeDate": {
-                    "$ref": "#/definitions/Date"
-                  }
-                },
-                "required": ["name", "address"],
-                "type": "object"
-              },
-              "type": "array"
             }
           },
-          "required": ["certificate"],
+          "required": ["name"],
+          "type": "object"
+        },
+        "email": {
+          "$ref": "#/definitions/Email"
+        },
+        "interest": {
+          "enum": ["owner.sole", "owner.co", "tenant", "occupier", "other"],
+          "type": "string"
+        },
+        "name": {
+          "additionalProperties": false,
+          "properties": {
+            "first": {
+              "type": "string"
+            },
+            "last": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "required": ["first", "last"],
+          "type": "object"
+        },
+        "ownership": {
+          "$ref": "#/definitions/Ownership"
+        },
+        "phone": {
+          "additionalProperties": false,
+          "properties": {
+            "primary": {
+              "type": "string"
+            }
+          },
+          "required": ["primary"],
           "type": "object"
         },
         "siteContact": {
@@ -112,7 +147,15 @@
           "type": "string"
         }
       },
-      "required": ["address", "agent", "contact", "siteContact", "type"],
+      "required": [
+        "address",
+        "agent",
+        "email",
+        "name",
+        "phone",
+        "siteContact",
+        "type"
+      ],
       "type": "object"
     },
     "Applicant": {
@@ -133,34 +176,7 @@
       "description": "Information about this planning application",
       "properties": {
         "declaration": {
-          "additionalProperties": false,
-          "properties": {
-            "accurate": {
-              "type": "boolean"
-            },
-            "connection": {
-              "additionalProperties": false,
-              "properties": {
-                "description": {
-                  "type": "string"
-                },
-                "value": {
-                  "enum": [
-                    "employee",
-                    "relation.employee",
-                    "electedMember",
-                    "relation.electedMember",
-                    "none"
-                  ],
-                  "type": "string"
-                }
-              },
-              "required": ["value"],
-              "type": "object"
-            }
-          },
-          "required": ["accurate", "connection"],
-          "type": "object"
+          "$ref": "#/definitions/ApplicationDeclaration"
         },
         "fee": {
           "$ref": "#/definitions/ApplicationFee"
@@ -173,6 +189,38 @@
         }
       },
       "required": ["type", "fee", "declaration"],
+      "type": "object"
+    },
+    "ApplicationDeclaration": {
+      "$id": "#ApplicationDeclaration",
+      "additionalProperties": false,
+      "description": "Declarations about the accuracy of this application and any personal connections to the receiving authority",
+      "properties": {
+        "accurate": {
+          "type": "boolean"
+        },
+        "connection": {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "value": {
+              "enum": [
+                "employee",
+                "relation.employee",
+                "electedMember",
+                "relation.electedMember",
+                "none"
+              ],
+              "type": "string"
+            }
+          },
+          "required": ["value"],
+          "type": "object"
+        }
+      },
+      "required": ["accurate", "connection"],
       "type": "object"
     },
     "ApplicationFee": {
@@ -219,6 +267,7 @@
           "additionalProperties": false,
           "properties": {
             "govPay": {
+              "description": "GOV.UK Pay payment reference number",
               "type": "string"
             }
           },
@@ -251,7 +300,7 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Lawful Development Certificate - Proposed",
+              "const": "Lawful Development Certificate - Proposed use",
               "type": "string"
             },
             "value": {
@@ -266,11 +315,41 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Lawful Development Certificate - Existing",
+              "const": "Lawful Development Certificate - Existing use",
               "type": "string"
             },
             "value": {
               "const": "ldc.existing",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Lawful Development Certificate - Continue an existing use",
+              "type": "string"
+            },
+            "value": {
+              "const": "ldc.existing.regularise",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Lawful Development Certificate - Lawful not to comply with a condition or limitation",
+              "type": "string"
+            },
+            "value": {
+              "const": "ldc.condition",
               "type": "string"
             }
           },
@@ -744,6 +823,27 @@
       "required": ["squareMetres"],
       "type": "object"
     },
+    "BBox": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "number"
+          },
+          "maxItems": 4,
+          "minItems": 4,
+          "type": "array"
+        },
+        {
+          "items": {
+            "type": "number"
+          },
+          "maxItems": 6,
+          "minItems": 6,
+          "type": "array"
+        }
+      ],
+      "description": "Bounding box https://tools.ietf.org/html/rfc7946#section-5"
+    },
     "BaseApplicant": {
       "$id": "#BaseApplicant",
       "additionalProperties": false,
@@ -752,51 +852,50 @@
         "address": {
           "$ref": "#/definitions/UserAddress"
         },
-        "contact": {
-          "$ref": "#/definitions/UserContact"
-        },
-        "interest": {
-          "enum": ["owner.sole", "owner.co", "tenant", "occupier"],
-          "type": "string"
-        },
-        "ownership": {
+        "company": {
           "additionalProperties": false,
           "properties": {
-            "certificate": {
-              "enum": ["a", "b", "c", "d"],
+            "name": {
               "type": "string"
-            },
-            "noticeGiven": {
-              "type": "boolean"
-            },
-            "owners": {
-              "items": {
-                "additionalProperties": false,
-                "properties": {
-                  "address": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/definitions/AddressInput"
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ]
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "noticeDate": {
-                    "$ref": "#/definitions/Date"
-                  }
-                },
-                "required": ["name", "address"],
-                "type": "object"
-              },
-              "type": "array"
             }
           },
-          "required": ["certificate"],
+          "required": ["name"],
+          "type": "object"
+        },
+        "email": {
+          "$ref": "#/definitions/Email"
+        },
+        "interest": {
+          "enum": ["owner.sole", "owner.co", "tenant", "occupier", "other"],
+          "type": "string"
+        },
+        "name": {
+          "additionalProperties": false,
+          "properties": {
+            "first": {
+              "type": "string"
+            },
+            "last": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "required": ["first", "last"],
+          "type": "object"
+        },
+        "ownership": {
+          "$ref": "#/definitions/Ownership"
+        },
+        "phone": {
+          "additionalProperties": false,
+          "properties": {
+            "primary": {
+              "type": "string"
+            }
+          },
+          "required": ["primary"],
           "type": "object"
         },
         "siteContact": {
@@ -813,7 +912,7 @@
           "type": "string"
         }
       },
-      "required": ["type", "contact", "address", "siteContact"],
+      "required": ["type", "name", "email", "phone", "address", "siteContact"],
       "type": "object"
     },
     "BaseDetails": {
@@ -869,6 +968,87 @@
       "format": "email",
       "type": "string"
     },
+    "Feature": {
+      "additionalProperties": false,
+      "description": "A feature object which contains a geometry and associated properties. https://tools.ietf.org/html/rfc7946#section-3.2",
+      "properties": {
+        "bbox": {
+          "$ref": "#/definitions/BBox",
+          "description": "Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections. The value of the bbox member is an array of length 2*n where n is the number of dimensions represented in the contained geometries, with all axes of the most southwesterly point followed by all axes of the more northeasterly point. The axes order of a bbox follows the axes order of geometries. https://tools.ietf.org/html/rfc7946#section-5"
+        },
+        "geometry": {
+          "$ref": "#/definitions/Geometry",
+          "description": "The feature's geometry"
+        },
+        "id": {
+          "description": "A value that uniquely identifies this feature in a https://tools.ietf.org/html/rfc7946#section-3.2.",
+          "type": ["string", "number"]
+        },
+        "properties": {
+          "$ref": "#/definitions/GeoJsonProperties",
+          "description": "Properties associated with this feature."
+        },
+        "type": {
+          "const": "Feature",
+          "description": "Specifies the type of GeoJSON object.",
+          "type": "string"
+        }
+      },
+      "required": ["geometry", "properties", "type"],
+      "type": "object"
+    },
+    "Feature<Geometry,GeoJsonProperties>": {
+      "additionalProperties": false,
+      "description": "A feature object which contains a geometry and associated properties. https://tools.ietf.org/html/rfc7946#section-3.2",
+      "properties": {
+        "bbox": {
+          "$ref": "#/definitions/BBox",
+          "description": "Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections. The value of the bbox member is an array of length 2*n where n is the number of dimensions represented in the contained geometries, with all axes of the most southwesterly point followed by all axes of the more northeasterly point. The axes order of a bbox follows the axes order of geometries. https://tools.ietf.org/html/rfc7946#section-5"
+        },
+        "geometry": {
+          "$ref": "#/definitions/Geometry",
+          "description": "The feature's geometry"
+        },
+        "id": {
+          "description": "A value that uniquely identifies this feature in a https://tools.ietf.org/html/rfc7946#section-3.2.",
+          "type": ["string", "number"]
+        },
+        "properties": {
+          "$ref": "#/definitions/GeoJsonProperties",
+          "description": "Properties associated with this feature."
+        },
+        "type": {
+          "const": "Feature",
+          "description": "Specifies the type of GeoJSON object.",
+          "type": "string"
+        }
+      },
+      "required": ["geometry", "properties", "type"],
+      "type": "object"
+    },
+    "FeatureCollection": {
+      "additionalProperties": false,
+      "description": "A collection of feature objects.  https://tools.ietf.org/html/rfc7946#section-3.3",
+      "properties": {
+        "bbox": {
+          "$ref": "#/definitions/BBox",
+          "description": "Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections. The value of the bbox member is an array of length 2*n where n is the number of dimensions represented in the contained geometries, with all axes of the most southwesterly point followed by all axes of the more northeasterly point. The axes order of a bbox follows the axes order of geometries. https://tools.ietf.org/html/rfc7946#section-5"
+        },
+        "features": {
+          "items": {
+            "$ref": "#/definitions/Feature%3CGeometry%2CGeoJsonProperties%3E"
+          },
+          "type": "array"
+        },
+        "type": {
+          "const": "FeatureCollection",
+          "description": "Specifies the type of GeoJSON object.",
+          "type": "string"
+        }
+      },
+      "required": ["features", "type"],
+      "type": "object"
+    },
     "File": {
       "$id": "#File",
       "additionalProperties": false,
@@ -897,7 +1077,22 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Elevation plan - existing",
+              "const": "Evidence for application fee exemption - disability",
+              "type": "string"
+            },
+            "value": {
+              "const": "applicant.disability.evidence",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Elevations - existing",
               "type": "string"
             },
             "value": {
@@ -942,7 +1137,7 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Section - existing",
+              "const": "Sections - existing",
               "type": "string"
             },
             "value": {
@@ -1002,22 +1197,7 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Location plan",
-              "type": "string"
-            },
-            "value": {
-              "const": "property.site.locationPlan",
-              "type": "string"
-            }
-          },
-          "required": ["value", "description"],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "const": "Elevation plan - proposed",
+              "const": "Elevations - proposed",
               "type": "string"
             },
             "value": {
@@ -1037,6 +1217,21 @@
             },
             "value": {
               "const": "proposal.drawing.floorPlan",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Location plan",
+              "type": "string"
+            },
+            "value": {
+              "const": "proposal.drawing.locationPlan",
               "type": "string"
             }
           },
@@ -1077,7 +1272,7 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Section - proposed",
+              "const": "Sections - proposed",
               "type": "string"
             },
             "value": {
@@ -1422,6 +1617,21 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Photographs - evidence",
+              "type": "string"
+            },
+            "value": {
+              "const": "proposal.photograph.evidence",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Visualisations",
               "type": "string"
             },
@@ -1437,11 +1647,105 @@
       "description": "Types of planning documents and drawings"
     },
     "GeoJSON": {
-      "$id": "#GeoJSON",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Geometry"
+        },
+        {
+          "$ref": "#/definitions/Feature"
+        },
+        {
+          "$ref": "#/definitions/FeatureCollection"
+        }
+      ],
+      "description": "Union of GeoJSON objects."
+    },
+    "GeoJsonProperties": {
+      "anyOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "Geometry": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Point"
+        },
+        {
+          "$ref": "#/definitions/MultiPoint"
+        },
+        {
+          "$ref": "#/definitions/LineString"
+        },
+        {
+          "$ref": "#/definitions/MultiLineString"
+        },
+        {
+          "$ref": "#/definitions/Polygon"
+        },
+        {
+          "$ref": "#/definitions/MultiPolygon"
+        },
+        {
+          "$ref": "#/definitions/GeometryCollection"
+        }
+      ],
+      "description": "Geometry object. https://tools.ietf.org/html/rfc7946#section-3"
+    },
+    "GeometryCollection": {
+      "additionalProperties": false,
+      "description": "Geometry Collection https://tools.ietf.org/html/rfc7946#section-3.1.8",
+      "properties": {
+        "bbox": {
+          "$ref": "#/definitions/BBox",
+          "description": "Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections. The value of the bbox member is an array of length 2*n where n is the number of dimensions represented in the contained geometries, with all axes of the most southwesterly point followed by all axes of the more northeasterly point. The axes order of a bbox follows the axes order of geometries. https://tools.ietf.org/html/rfc7946#section-5"
+        },
+        "geometries": {
+          "items": {
+            "$ref": "#/definitions/Geometry"
+          },
+          "type": "array"
+        },
+        "type": {
+          "const": "GeometryCollection",
+          "description": "Specifies the type of GeoJSON object.",
+          "type": "string"
+        }
+      },
+      "required": ["geometries", "type"],
+      "type": "object"
+    },
+    "LineString": {
+      "additionalProperties": false,
+      "description": "LineString geometry object. https://tools.ietf.org/html/rfc7946#section-3.1.4",
+      "properties": {
+        "bbox": {
+          "$ref": "#/definitions/BBox",
+          "description": "Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections. The value of the bbox member is an array of length 2*n where n is the number of dimensions represented in the contained geometries, with all axes of the most southwesterly point followed by all axes of the more northeasterly point. The axes order of a bbox follows the axes order of geometries. https://tools.ietf.org/html/rfc7946#section-5"
+        },
+        "coordinates": {
+          "items": {
+            "$ref": "#/definitions/Position"
+          },
+          "type": "array"
+        },
+        "type": {
+          "const": "LineString",
+          "description": "Specifies the type of GeoJSON object.",
+          "type": "string"
+        }
+      },
+      "required": ["coordinates", "type"],
       "type": "object"
     },
     "LondonDetails": {
+      "$id": "#LondonDetails",
       "additionalProperties": false,
+      "description": "Proposal details for project sites within the Greater London Authority (GLA) area",
       "properties": {
         "extend": {
           "additionalProperties": false,
@@ -1958,7 +2262,7 @@
     "LondonProperty": {
       "$id": "#LondonProperty",
       "additionalProperties": false,
-      "description": "Property details for sites within London",
+      "description": "Property details for sites within the Greater London Authority (GLA) area",
       "properties": {
         "EPC": {
           "additionalProperties": false,
@@ -1977,6 +2281,7 @@
             }
           },
           "required": ["known"],
+          "title": "Energy Performance Certificate",
           "type": "object"
         },
         "address": {
@@ -2016,12 +2321,14 @@
           "type": "object"
         },
         "localAuthorityDistrict": {
+          "description": "Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "region": {
+          "const": "London",
           "type": "string"
         },
         "titleNumber": {
@@ -2045,6 +2352,7 @@
       "required": [
         "EPC",
         "address",
+        "constraints",
         "localAuthorityDistrict",
         "region",
         "titleNumber",
@@ -2125,15 +2433,95 @@
       "required": ["service", "session", "schema"],
       "type": "object"
     },
+    "MultiLineString": {
+      "additionalProperties": false,
+      "description": "MultiLineString geometry object. https://tools.ietf.org/html/rfc7946#section-3.1.5",
+      "properties": {
+        "bbox": {
+          "$ref": "#/definitions/BBox",
+          "description": "Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections. The value of the bbox member is an array of length 2*n where n is the number of dimensions represented in the contained geometries, with all axes of the most southwesterly point followed by all axes of the more northeasterly point. The axes order of a bbox follows the axes order of geometries. https://tools.ietf.org/html/rfc7946#section-5"
+        },
+        "coordinates": {
+          "items": {
+            "items": {
+              "$ref": "#/definitions/Position"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "type": {
+          "const": "MultiLineString",
+          "description": "Specifies the type of GeoJSON object.",
+          "type": "string"
+        }
+      },
+      "required": ["coordinates", "type"],
+      "type": "object"
+    },
+    "MultiPoint": {
+      "additionalProperties": false,
+      "description": "MultiPoint geometry object.  https://tools.ietf.org/html/rfc7946#section-3.1.3",
+      "properties": {
+        "bbox": {
+          "$ref": "#/definitions/BBox",
+          "description": "Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections. The value of the bbox member is an array of length 2*n where n is the number of dimensions represented in the contained geometries, with all axes of the most southwesterly point followed by all axes of the more northeasterly point. The axes order of a bbox follows the axes order of geometries. https://tools.ietf.org/html/rfc7946#section-5"
+        },
+        "coordinates": {
+          "items": {
+            "$ref": "#/definitions/Position"
+          },
+          "type": "array"
+        },
+        "type": {
+          "const": "MultiPoint",
+          "description": "Specifies the type of GeoJSON object.",
+          "type": "string"
+        }
+      },
+      "required": ["coordinates", "type"],
+      "type": "object"
+    },
+    "MultiPolygon": {
+      "additionalProperties": false,
+      "description": "MultiPolygon geometry object. https://tools.ietf.org/html/rfc7946#section-3.1.7",
+      "properties": {
+        "bbox": {
+          "$ref": "#/definitions/BBox",
+          "description": "Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections. The value of the bbox member is an array of length 2*n where n is the number of dimensions represented in the contained geometries, with all axes of the most southwesterly point followed by all axes of the more northeasterly point. The axes order of a bbox follows the axes order of geometries. https://tools.ietf.org/html/rfc7946#section-5"
+        },
+        "coordinates": {
+          "items": {
+            "items": {
+              "items": {
+                "$ref": "#/definitions/Position"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "type": {
+          "const": "MultiPolygon",
+          "description": "Specifies the type of GeoJSON object.",
+          "type": "string"
+        }
+      },
+      "required": ["coordinates", "type"],
+      "type": "object"
+    },
     "OSAddress": {
       "$id": "#OSAddress",
       "additionalProperties": false,
       "description": "Address information for sites with a known address sourced from Ordnance Survey AddressBase Premium",
       "properties": {
         "latitude": {
+          "description": "Latitude coordinate in EPSG:4326 (WGS84)",
           "type": "number"
         },
         "longitude": {
+          "description": "Longitude coordinate in EPSG:4326 (WGS84)",
           "type": "number"
         },
         "organisation": {
@@ -2162,15 +2550,21 @@
           "type": "string"
         },
         "uprn": {
+          "maxLength": 12,
+          "title": "Unique Property Reference Number",
           "type": "string"
         },
         "usrn": {
+          "maxLength": 8,
+          "title": "Unique Street Reference Number",
           "type": "string"
         },
         "x": {
+          "description": "Easting coordinate in British National Grid (OSGB36)",
           "type": "number"
         },
         "y": {
+          "description": "Northing coordinate in British National Grid (OSGB36)",
           "type": "number"
         }
       },
@@ -2189,6 +2583,48 @@
         "x",
         "y"
       ],
+      "type": "object"
+    },
+    "Ownership": {
+      "$id": "#Ownership",
+      "additionalProperties": false,
+      "description": "Information about the ownership certificate and property owners, if different than the applicant",
+      "properties": {
+        "certificate": {
+          "enum": ["a", "b", "c", "d"],
+          "type": "string"
+        },
+        "noticeGiven": {
+          "type": "boolean"
+        },
+        "owners": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "address": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Address"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "name": {
+                "type": "string"
+              },
+              "noticeDate": {
+                "$ref": "#/definitions/Date"
+              }
+            },
+            "required": ["name", "address"],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "required": ["certificate"],
       "type": "object"
     },
     "PlanningConstraint": {
@@ -4089,6 +4525,59 @@
       ],
       "description": "Planning constraints that overlap with the property site boundary determined by spatial queries against Planning Data (planning.data.gov.uk) and Ordnance Survey"
     },
+    "Point": {
+      "additionalProperties": false,
+      "description": "Point geometry object. https://tools.ietf.org/html/rfc7946#section-3.1.2",
+      "properties": {
+        "bbox": {
+          "$ref": "#/definitions/BBox",
+          "description": "Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections. The value of the bbox member is an array of length 2*n where n is the number of dimensions represented in the contained geometries, with all axes of the most southwesterly point followed by all axes of the more northeasterly point. The axes order of a bbox follows the axes order of geometries. https://tools.ietf.org/html/rfc7946#section-5"
+        },
+        "coordinates": {
+          "$ref": "#/definitions/Position"
+        },
+        "type": {
+          "const": "Point",
+          "description": "Specifies the type of GeoJSON object.",
+          "type": "string"
+        }
+      },
+      "required": ["coordinates", "type"],
+      "type": "object"
+    },
+    "Polygon": {
+      "additionalProperties": false,
+      "description": "Polygon geometry object. https://tools.ietf.org/html/rfc7946#section-3.1.6",
+      "properties": {
+        "bbox": {
+          "$ref": "#/definitions/BBox",
+          "description": "Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections. The value of the bbox member is an array of length 2*n where n is the number of dimensions represented in the contained geometries, with all axes of the most southwesterly point followed by all axes of the more northeasterly point. The axes order of a bbox follows the axes order of geometries. https://tools.ietf.org/html/rfc7946#section-5"
+        },
+        "coordinates": {
+          "items": {
+            "items": {
+              "$ref": "#/definitions/Position"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "type": {
+          "const": "Polygon",
+          "description": "Specifies the type of GeoJSON object.",
+          "type": "string"
+        }
+      },
+      "required": ["coordinates", "type"],
+      "type": "object"
+    },
+    "Position": {
+      "description": "A Position is an array of coordinates. https://tools.ietf.org/html/rfc7946#section-3.1.1 Array should contain between two and three elements. The previous GeoJSON specification allowed more elements (e.g., which could be used to represent M values), but the current specification only allows X, Y, and (optionally) Z to be defined.",
+      "items": {
+        "type": "number"
+      },
+      "type": "array"
+    },
     "PreApplication": {
       "$id": "#PreApplication",
       "additionalProperties": false,
@@ -4113,6 +4602,21 @@
     "ProjectType": {
       "$id": "#ProjectType",
       "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Alter a building",
+              "type": "string"
+            },
+            "value": {
+              "const": "alter",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
         {
           "additionalProperties": false,
           "properties": {
@@ -5782,7 +6286,7 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Convert a building to a different use",
+              "const": "Change the use of a building",
               "type": "string"
             },
             "value": {
@@ -6027,6 +6531,21 @@
             },
             "value": {
               "const": "demolish.replace",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Extend a building or add an outbuilding",
+              "type": "string"
+            },
+            "value": {
+              "const": "extend",
               "type": "string"
             }
           },
@@ -6772,7 +7291,7 @@
           "additionalProperties": false,
           "properties": {
             "description": {
-              "const": "Another type of building",
+              "const": "Add another type of building",
               "type": "string"
             },
             "value": {
@@ -7047,6 +7566,21 @@
             },
             "value": {
               "const": "new.warehouse",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Change of units",
+              "type": "string"
+            },
+            "value": {
+              "const": "unit",
               "type": "string"
             }
           },
@@ -14083,16 +14617,7 @@
           "type": "object"
         },
         "date": {
-          "additionalProperties": false,
-          "properties": {
-            "completion": {
-              "$ref": "#/definitions/Date"
-            },
-            "start": {
-              "$ref": "#/definitions/Date"
-            }
-          },
-          "type": "object"
+          "$ref": "#/definitions/ProposalDates"
         },
         "description": {
           "type": "string"
@@ -14108,6 +14633,20 @@
         }
       },
       "required": ["projectType", "description"],
+      "type": "object"
+    },
+    "ProposalDates": {
+      "$id": "#ProposalDates",
+      "additionalProperties": false,
+      "description": "When the proposed works will start and be completed by, not required for all application types",
+      "properties": {
+        "completion": {
+          "$ref": "#/definitions/Date"
+        },
+        "start": {
+          "$ref": "#/definitions/Date"
+        }
+      },
       "type": "object"
     },
     "ProposalDetails": {
@@ -14128,9 +14667,11 @@
       "description": "Address information for sites without a known Unique Property Reference Number (UPRN)",
       "properties": {
         "latitude": {
+          "description": "Latitude coordinate in EPSG:4326 (WGS84)",
           "type": "number"
         },
         "longitude": {
+          "description": "Longitude coordinate in EPSG:4326 (WGS84)",
           "type": "number"
         },
         "source": {
@@ -14141,9 +14682,11 @@
           "type": "string"
         },
         "x": {
+          "description": "Easting coordinate in British National Grid (OSGB36)",
           "type": "number"
         },
         "y": {
+          "description": "Northing coordinate in British National Grid (OSGB36)",
           "type": "number"
         }
       },
@@ -14800,20 +15343,43 @@
           "type": "object"
         },
         "localAuthorityDistrict": {
+          "description": "Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "region": {
-          "type": "string"
+          "$ref": "#/definitions/UKRegion"
         },
         "type": {
           "$ref": "#/definitions/PropertyType"
         }
       },
-      "required": ["address", "region", "localAuthorityDistrict", "type"],
+      "required": [
+        "address",
+        "region",
+        "localAuthorityDistrict",
+        "type",
+        "constraints"
+      ],
       "type": "object"
+    },
+    "UKRegion": {
+      "$id": "#UKRegion",
+      "description": "The UK region that contains this address sourced from planning.data.gov.uk/dataset/region, where London is a proxy for the Greater London Authority (GLA) area",
+      "enum": [
+        "North East",
+        "North West",
+        "Yorkshire and The Humber",
+        "East Midlands",
+        "West Midlands",
+        "East of England",
+        "London",
+        "South East",
+        "South West"
+      ],
+      "type": "string"
     },
     "URL": {
       "format": "uri",
@@ -14860,7 +15426,7 @@
     "UserAddressNotSameSite": {
       "$id": "#UserAddressNotSameSite",
       "additionalProperties": false,
-      "description": "Address information for an applicant with contact information that differs from the site address",
+      "description": "Address information for an applicant with contact information that differs from the property address",
       "properties": {
         "country": {
           "type": "string"
@@ -14886,53 +15452,6 @@
         }
       },
       "required": ["line1", "postcode", "sameAsSiteAddress", "town"],
-      "type": "object"
-    },
-    "UserContact": {
-      "$id": "#UserContact",
-      "additionalProperties": false,
-      "description": "Contact information for any user",
-      "properties": {
-        "company": {
-          "additionalProperties": false,
-          "properties": {
-            "name": {
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "email": {
-          "$ref": "#/definitions/Email"
-        },
-        "name": {
-          "additionalProperties": false,
-          "properties": {
-            "first": {
-              "type": "string"
-            },
-            "last": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
-            }
-          },
-          "required": ["first", "last"],
-          "type": "object"
-        },
-        "phone": {
-          "additionalProperties": false,
-          "properties": {
-            "primary": {
-              "type": "string"
-            }
-          },
-          "required": ["primary"],
-          "type": "object"
-        }
-      },
-      "required": ["name", "email", "phone"],
       "type": "object"
     },
     "VehicleParking": {
@@ -15302,7 +15821,7 @@
       "description": "Vehicle parking types"
     }
   },
-  "description": "The root schema for an application generated by a digital planning service",
+  "description": "The root specification for a planning application in England generated by a digital planning service",
   "properties": {
     "data": {
       "additionalProperties": false,

--- a/src/export/digitalPlanning/schema/schema.json
+++ b/src/export/digitalPlanning/schema/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "@next",
+  "$id": "v0.1.2",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "definitions": {


### PR DESCRIPTION
- adds schema v0.1.2 & generates new types
- improves passport mapping throughout (especially more conditional checks to omit optional properties rather than include as `{}`)