### PR TITLE
feat: Optimise `sortBreadcrumbs()`

### DIFF
--- a/src/models/session/logic.test.ts
+++ b/src/models/session/logic.test.ts
@@ -101,7 +101,7 @@ describe("findNextNodeOfType", () => {
   });
 
   test("it finds the next node in a branching flow", () => {
-    const mulitselectChecklistBreadcrumbs = {
+    const multiselectChecklistBreadcrumbs = {
       Section1: { auto: true },
       Question1: { auto: false, answers: ["Question1AnswerA"] },
       Section2: { auto: true },
@@ -113,7 +113,7 @@ describe("findNextNodeOfType", () => {
     };
     const nextNoticeNode = findNextNodeOfType({
       flow: branching.flow,
-      breadcrumbs: mulitselectChecklistBreadcrumbs,
+      breadcrumbs: multiselectChecklistBreadcrumbs,
       componentType: ComponentType.Notice,
     });
     expect(nextNoticeNode).toEqual({
@@ -125,7 +125,7 @@ describe("findNextNodeOfType", () => {
     });
     const nextSectionNode = findNextNodeOfType({
       flow: branching.flow,
-      breadcrumbs: mulitselectChecklistBreadcrumbs,
+      breadcrumbs: multiselectChecklistBreadcrumbs,
       componentType: ComponentType.Section,
     });
     expect(nextSectionNode).toEqual({


### PR DESCRIPTION
## What's the problem?
Recent submissions have been causing the API to crash, due to it running out of CPU. [We've bumped this a few times](https://github.com/theopensystemslab/planx-new/pull/2345) but are still seeing huge spikes on submission. 

[Profiling](https://nodejs.org/docs/latest-v18.x/api/inspector.html#cpu-profiler) `computeBOPSParams()` which the the main function which reads a session and flow and converts to various formats points towards `searchNodeEdges()` as being the leading cause.

## What's causing the high CPU usage?
`searchNodeEdges()` is currently doing a whole lot - 
 - Recursively navigating through the entire flow
 - Iterating through `breadcrumbIds`
 - Reducing and generating `answerData`
 - Generating an `orderedBreadcrumb`

On the mock flow in tests, this is happening 420,000+ times 👀 


## What approach was taken?
I did a fair bit of reading up on ways we could improve this, and this is very much a first pass for now. [This StackOverflow answer](https://codereview.stackexchange.com/a/272783) is a fair summary of the approach -
 - Don't compare strings (UUIDs)
 - Avoid extra iteration (looping over `breadcumbIds`)
 - Reduce scope of variables
 - Don't define new variables which can't be garbage collected until the "main" loop traversing the entire flow has been completed

What I've aimed to do is simplify the flow traversal to avoid as many of the above as possible. We can then iterate over the `visited` array and generate other data structures much more easily on a scale several orders of magnitude smaller.


## What are the outcomes?
Seems pretty good! Running locally it's approx 5 times faster so it's certainly an improvement. Quite what this converts to on the AWS infrastructure remains to be seen - see comments on testing below.

| Before | After |
|--------|--------|
| <img width="560" alt="image" src="https://github.com/theopensystemslab/planx-core/assets/20502206/6138fe43-7e05-48f0-8f22-0fedb2c1adfa"> | <img width="583" alt="image" src="https://github.com/theopensystemslab/planx-core/assets/20502206/238b9b4b-f669-4480-aa34-7d6c27dd0c99">|

## How can we test this?
A few ideas here - testing locally is fine and there's "real" mock data being used in tests, but we won't have a decent degree of certainty until we reach the staging environments. I'd suggest that post-review we try this on staging with real flows and customer data, then check Fargate CPU usage vs production on the `/admin/session/:sessionId/bops` endpoints.

We could also take a slightly more cautious approach and add a query param to trigger the old vs new functions for a more like for like comparison if this seems wise? Open to suggestions here!


## Next steps...
Let's see the outcomes of this, and hopefully reduce the container CPU and memory as a result 🤞 

I've also been working on a "filtered" view of a flow which is just an intersection of a flow with a user's breadcrumbs (and answers). Initial testing shows (for the mock data) this would bring the total number of nodes in a flow from 176,000 → 280 which would be another significant change.

Some of the lessons learned here can certainly applied to other flow traversal methods. I've been reading up a little on [OpenTelemetry](https://opentelemetry.io/) as a more "generic" option to help us identify issues sooner, but honestly an off the shelf solution like [Sentry](https://sentry.io/) might be a better use of time (and also a replacement for Airbrake?). Something for a spike!

Update: turns out Airbrake has some of this functionality as well, we're just not using it. I'll make a ticket to investigate this 👌 