### PR TITLE
fix: Convert emails to lowercase on request to match insert

### DIFF
--- a/src/requests/user.ts
+++ b/src/requests/user.ts
@@ -141,7 +141,7 @@ async function getByEmail(
         }
       }
     `,
-    { email },
+    { email: email.toLowerCase() },
   );
   return users?.[0] || null;
 }


### PR DESCRIPTION
Currently E2E tests are failing as `team1-teamEditor-user@example.com` !== `team1-teameditor-user@example.com` 🤦 

See https://github.com/theopensystemslab/planx-core/pull/175