### PR TITLE
fix: update passport <> ODP Schema mappings

### DIFF
--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -360,7 +360,11 @@ export class DigitalPlanning {
       }),
     };
 
-    if (this.passport.data?._address?.["property.region"]?.[0] === "London") {
+    // Prior Approvals will use London Data Hub in future, but don't yet https://editor.planx.uk/opensystemslab/prior-approval-more-information
+    if (
+      this.passport.data?.["property.region"]?.[0] === "London" &&
+      !this.passport.data?.["application.type"]?.[0]?.startsWith("pa")
+    ) {
       return {
         ...baseProperty,
         titleNumber: {
@@ -450,8 +454,8 @@ export class DigitalPlanning {
   private getApplicationFee(): Payload["data"]["application"]["fee"] {
     const baseFee = {
       calculated:
-        this.passport.generic<number>("application.fee.calculated") || 0,
-      payable: this.passport.generic<number>("application.fee.payable") || 0,
+        (this.passport.data?.["application.fee.calculated"] as number) || 0,
+      payable: (this.passport.data?.["application.fee.payable"] as number) || 0,
       exemption: {
         disability: this.stringToBool(
           this.passport.data?.["application.fee.exemption.disability"]?.[0],
@@ -534,7 +538,7 @@ export class DigitalPlanning {
   private getProposal(): Proposal {
     const baseProposal = {
       projectType: (
-        this.passport.generic<string[]>("proposal.projectType") || []
+        (this.passport.data?.["proposal.projectType"] as string[]) || []
       ).map((project: string) => {
         return {
           value: project,
@@ -544,8 +548,8 @@ export class DigitalPlanning {
       description:
         this.passport.data?.["proposal.description"] || "Not provided",
       date: {
-        start: this.passport.generic<string>("proposal.start.date"),
-        completion: this.passport.generic<string>("proposal.completion.date"), // this.passport.data?.["proposal.finish.date"],
+        start: this.passport.data?.["proposal.start.date"] as string,
+        completion: this.passport.data?.["proposal.completion.date"] as string,
       },
       ...(this.passport.data?.["property.boundary.site"] && {
         boundary: this.getBoundary(),
@@ -583,10 +587,9 @@ export class DigitalPlanning {
       );
     }
 
-    const vehicleParking = this.passport.generic<string[]>(
-      "proposal.vehicleParking",
-    );
-
+    const vehicleParking = this.passport.data?.[
+      "proposal.vehicleParking"
+    ] as string[];
     if (vehicleParking && vehicleParking.length > 0) {
       set(
         baseProposal,


### PR DESCRIPTION
Was checking recent application payloads today (eg [admin endpoint for BOPS](https://api.editor.planx.uk/admin/session/6508e9bd-a50e-4621-b6d9-f9cd3e23a214/bops) compared to [admin endpoint for schema](https://api.editor.planx.uk/admin/session/6508e9bd-a50e-4621-b6d9-f9cd3e23a214/digital-planning-application) for the most recent Southwark LDC) and I noticed some unexpected 0s and undefineds in the new schema mapping. 

Confusingly, these still validate successfully but are false data - it's easy to overlook!

It seems most of these were introduced through the use of `generic<>` which I've removed here for now, in favor of the clunkier syntax `as <type>`. Very open to other suggestions.

Examples in the ODP schema repo are okay as I've been updating them section-by-section for a bit now (eg just log out new `planning.designations` shape from model.test.ts here and copy over to examples in other repo rather than full payload), but this also meant that this mapping bug has gone unnoticed for awhile.

Please take a look at the admin endpoints and shout if you spot any other inconsistencies not addressed here! We'll start sending to BOPS soon and I'm keen to make sure data mappings and validation are tight on our side.