### PR TITLE
chore: Update marked to v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "lodash.omit": "^4.5.0",
     "lodash.set": "^4.3.2",
     "lodash.startcase": "^4.4.0",
-    "marked": "^9.1.5",
+    "marked": "^11.0.0",
     "prettier": "^3.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ dependencies:
     specifier: ^4.4.0
     version: 4.4.0
   marked:
-    specifier: ^9.1.5
-    version: 9.1.5
+    specifier: ^11.0.0
+    version: 11.0.0
   prettier:
     specifier: ^3.0.3
     version: 3.0.3
@@ -4547,9 +4547,9 @@ packages:
       object-visit: 1.0.1
     dev: true
 
-  /marked@9.1.5:
-    resolution: {integrity: sha512-14QG3shv8Kg/xc0Yh6TNkMj90wXH9mmldi5941I2OevfJ/FQAFLEwtwU2/FfgSAOMlWHrEukWSGQf8MiVYNG2A==}
-    engines: {node: '>= 16'}
+  /marked@11.0.0:
+    resolution: {integrity: sha512-2GsW34uXaFEGTQ/+3rCnNC6vUYTAgFuDLGl70v/aWinA5mIJtTrrFAmfbLOfVvgPyxXuDVL9He/7reCK+6j3Sw==}
+    engines: {node: '>= 18'}
     hasBin: true
     dev: false
 

--- a/src/export/bops/index.ts
+++ b/src/export/bops/index.ts
@@ -286,7 +286,7 @@ export function formatProposalDetails({
 }
 
 export const parsePolicyRefs = (markdownOrHTML: string) => {
-  const htmlString = marked.parse(markdownOrHTML);
+  const htmlString = marked.parse(markdownOrHTML, { async: false }) as string;
   const $ = load(htmlString);
   const policyRefs = $("a").map((_index, el) => ({
     text: $(el).prop("textContent")?.trim() ?? undefined,


### PR DESCRIPTION
Replaces #213 

Please see this issue for context: https://github.com/markedjs/marked/pull/3103