### PR TITLE
chore: account for title boundaries in document templates

### DIFF
--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -1,5 +1,6 @@
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
+import { Feature } from "geojson";
 import set from "lodash.set";
 
 import { Passport } from "../../models";
@@ -341,10 +342,15 @@ export class DigitalPlanning {
   }
 
   private getProposedBoundary(): Payload["data"]["proposal"]["boundary"] {
+    const annotatedBoundary = this.passport.data?.[
+      "property.boundary.site"
+    ] as unknown as Feature;
+    if (annotatedBoundary && annotatedBoundary.properties)
+      annotatedBoundary["properties"]["planx_user_action"] =
+        this.passport.data?.["drawBoundary.action"];
+
     return {
-      site: this.passport.data?.[
-        "property.boundary.site"
-      ] as unknown as GeoJSON,
+      site: annotatedBoundary as GeoJSON,
       area: {
         hectares:
           this.passport.data?.["proposal.siteArea.hectares"] ||

--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -342,9 +342,7 @@ export class DigitalPlanning {
 
   private getProposedBoundary(): Payload["data"]["proposal"]["boundary"] {
     return {
-      site: this.passport.data?.[
-        "property.boundary.site"
-      ] as unknown as GeoJSON,
+      site: geojson,
       area: {
         hectares:
           this.passport.data?.["proposal.siteArea.hectares"] ||

--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -342,7 +342,9 @@ export class DigitalPlanning {
 
   private getProposedBoundary(): Payload["data"]["proposal"]["boundary"] {
     return {
-      site: geojson,
+      site: this.passport.data?.[
+        "property.boundary.site"
+      ] as unknown as GeoJSON,
       area: {
         hectares:
           this.passport.data?.["proposal.siteArea.hectares"] ||

--- a/src/templates/generateExamples.ts
+++ b/src/templates/generateExamples.ts
@@ -52,6 +52,7 @@ async function generateHTMLExamples() {
   const sectionHTML = generateApplicationHTML({
     planXExportData: exampleWithSections.data,
     boundingBox: buckinghamshireBoundary,
+    userAction: DrawBoundaryUserAction.Draw,
   });
   writeFileSync(`./examples/application_with_sections.html`, sectionHTML);
 

--- a/src/templates/generateExamples.ts
+++ b/src/templates/generateExamples.ts
@@ -10,6 +10,7 @@ import { Packer } from "docx";
 
 import type { Passport as IPassport } from "../types";
 import { buildTestTemplate } from "./docx/testTemplate";
+import { DrawBoundaryUserAction } from "./html/map/Map";
 import {
   generateApplicationHTML,
   generateDocxTemplateStream,
@@ -56,6 +57,7 @@ async function generateHTMLExamples() {
   const mapHTML = generateMapHTML({
     geojson: exampleData.geojson,
     boundingBox: buckinghamshireBoundary,
+    userAction: DrawBoundaryUserAction.Draw,
   });
   writeFileSync(`./examples/map.html`, mapHTML);
 }

--- a/src/templates/generateExamples.ts
+++ b/src/templates/generateExamples.ts
@@ -45,6 +45,7 @@ async function generateHTMLExamples() {
   const applicationHTML = generateApplicationHTML({
     planXExportData: exampleData.data,
     boundingBox: buckinghamshireBoundary,
+    userAction: DrawBoundaryUserAction.Draw,
   });
   writeFileSync(`./examples/application.html`, applicationHTML);
 

--- a/src/templates/html/Main.tsx
+++ b/src/templates/html/Main.tsx
@@ -8,6 +8,7 @@ import { buckinghamshireBoundary } from "../mocks/buckinghamshireBoundary";
 import { MapHTML } from "./map/MapHTML";
 import { ApplicationHTML } from "./application/ApplicationHTML";
 import { exampleWithSections as example } from "../mocks";
+import { DrawBoundaryUserAction } from "./map/Map";
 
 interface TabPanelProps {
   children?: React.ReactNode;
@@ -52,6 +53,7 @@ function TemplatesViewer(): JSX.Element {
         <MapHTML
           geojson={example.geojson}
           boundingBox={buckinghamshireBoundary}
+          userAction={DrawBoundaryUserAction.Draw}
         />
       </TabPanel>
       <TabPanel value={value} index={1}>

--- a/src/templates/html/application/ApplicationHTML.tsx
+++ b/src/templates/html/application/ApplicationHTML.tsx
@@ -252,7 +252,7 @@ export function ApplicationHTML(props: {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <script src="https://cdn.jsdelivr.net/npm/@opensystemslab/map@0.7.5"></script>
+        <script src="https://cdn.jsdelivr.net/npm/@opensystemslab/map@0.7.9"></script>
         <title>{typeof documentTitle === "string" && documentTitle}</title>
         <link
           rel="stylesheet"

--- a/src/templates/html/application/ApplicationHTML.tsx
+++ b/src/templates/html/application/ApplicationHTML.tsx
@@ -17,6 +17,8 @@ import type {
   PlanXExportData,
 } from "../../../types";
 
+import Map, { DrawBoundaryUserAction } from "../map/Map";
+
 function Highlights(props: { data: PlanXExportData[] }): JSX.Element {
   const siteAddress = props.data.find((d) => d.question === "site")
     ?.responses as BOPSFullPayload["site"];
@@ -206,6 +208,7 @@ function DataItem(props: { data: PlanXExportData }) {
 export function ApplicationHTML(props: {
   data: PlanXExportData[];
   boundingBox: GeoJSON.Feature;
+  userAction?: DrawBoundaryUserAction;
 }) {
   // Pluck out some key questions & responses to show in special sections
   const applicationType: unknown = props.data.find(
@@ -284,15 +287,10 @@ export function ApplicationHTML(props: {
             <>
               {boundary && (
                 <Box sx={{ marginBottom: 1 }}>
-                  <my-map
-                    showNorthArrow={true}
-                    showScale={true}
-                    useScalebarStyle={true}
-                    hideResetControl={true}
-                    geojsonData={JSON.stringify(boundary)}
-                    id="boundary-map"
-                    showPrint={true}
-                    clipGeojsonData={JSON.stringify(props.boundingBox)}
+                  <Map
+                    boundary={boundary}
+                    clipGeojsonData={props.boundingBox}
+                    userAction={props.userAction}
                   />
                 </Box>
               )}

--- a/src/templates/html/map/Map.tsx
+++ b/src/templates/html/map/Map.tsx
@@ -48,9 +48,12 @@ export default function Map(props: {
     return (
       <>
         <my-map
+          id="boundary-map"
           showNorthArrow={true}
           hideResetControl={true}
           showScale={true}
+          useScalebarStyle={true}
+          showPrint={true}
           geojsonData={JSON.stringify(props.boundary)}
           clipGeojsonData={JSON.stringify(props.clipGeojsonData)}
           osCopyright={osCopyright}
@@ -65,9 +68,12 @@ export default function Map(props: {
     return (
       <>
         <my-map
+          id="boundary-map"
           showNorthArrow={true}
           hideResetControl={true}
           showScale={true}
+          useScalebarStyle={true}
+          showPrint={true}
           geojsonData={JSON.stringify(props.boundary)}
           clipGeojsonData={JSON.stringify(props.clipGeojsonData)}
         />

--- a/src/templates/html/map/Map.tsx
+++ b/src/templates/html/map/Map.tsx
@@ -46,25 +46,37 @@ export default function Map(props: {
     )
   ) {
     return (
-      <my-map
-        showNorthArrow={true}
-        hideResetControl={true}
-        showScale={true}
-        geojsonData={JSON.stringify(props.boundary)}
-        clipGeojsonData={JSON.stringify(props.clipGeojsonData)}
-        osCopyright={osCopyright}
-        geojsonDataCopyright={titleBoundaryCopyright}
-      />
+      <>
+        <my-map
+          showNorthArrow={true}
+          hideResetControl={true}
+          showScale={true}
+          geojsonData={JSON.stringify(props.boundary)}
+          clipGeojsonData={JSON.stringify(props.clipGeojsonData)}
+          osCopyright={osCopyright}
+          geojsonDataCopyright={titleBoundaryCopyright}
+        />
+        <p style={{ fontSize: ".7em" }}>
+          Source: PlanX user {props.userAction.toLowerCase()}.
+        </p>
+      </>
     );
   } else {
     return (
-      <my-map
-        showNorthArrow={true}
-        hideResetControl={true}
-        showScale={true}
-        geojsonData={JSON.stringify(props.boundary)}
-        clipGeojsonData={JSON.stringify(props.clipGeojsonData)}
-      />
+      <>
+        <my-map
+          showNorthArrow={true}
+          hideResetControl={true}
+          showScale={true}
+          geojsonData={JSON.stringify(props.boundary)}
+          clipGeojsonData={JSON.stringify(props.clipGeojsonData)}
+        />
+        {props.userAction && (
+          <p style={{ fontSize: ".7em" }}>
+            Source: PlanX user {props.userAction.toLowerCase()}.
+          </p>
+        )}
+      </>
     );
   }
 }

--- a/src/templates/html/map/Map.tsx
+++ b/src/templates/html/map/Map.tsx
@@ -1,5 +1,16 @@
 import * as React from "react";
 
+// Sourced from editor.planx.uk/src/@planx/components/DrawBoundary/model
+export enum DrawBoundaryUserAction {
+  Accept = "Accepted the title boundary",
+  Amend = "Amended the title boundary",
+  Draw = "Drew a custom boundary",
+  Upload = "Uploaded a location plan",
+}
+
+const osCopyright = `Basemap subject to Crown copyright and database rights ${new Date().getFullYear()} OS (0)100024857`;
+const titleBoundaryCopyright = `<a href="https://www.planning.data.gov.uk/dataset/title-boundary" target="_blank">Title boundary</a> subject to Crown copyright and database rights ${new Date().getFullYear()} OS (0)100026316`;
+
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
@@ -17,6 +28,8 @@ declare global {
       useScalebarStyle?: boolean;
       staticMode?: boolean;
       clipGeojsonData: string;
+      osCopyright?: string;
+      geojsonDataCopyright?: string;
     }
   }
 }
@@ -24,14 +37,34 @@ declare global {
 export default function Map(props: {
   boundary: object;
   clipGeojsonData: GeoJSON.Feature;
+  userAction?: DrawBoundaryUserAction;
 }) {
-  return (
-    <my-map
-      showNorthArrow={true}
-      hideResetControl={true}
-      showScale={true}
-      geojsonData={JSON.stringify(props.boundary)}
-      clipGeojsonData={JSON.stringify(props.clipGeojsonData)}
-    />
-  );
+  if (
+    props.userAction &&
+    [DrawBoundaryUserAction.Accept, DrawBoundaryUserAction.Amend].includes(
+      props.userAction,
+    )
+  ) {
+    return (
+      <my-map
+        showNorthArrow={true}
+        hideResetControl={true}
+        showScale={true}
+        geojsonData={JSON.stringify(props.boundary)}
+        clipGeojsonData={JSON.stringify(props.clipGeojsonData)}
+        osCopyright={osCopyright}
+        geojsonDataCopyright={titleBoundaryCopyright}
+      />
+    );
+  } else {
+    return (
+      <my-map
+        showNorthArrow={true}
+        hideResetControl={true}
+        showScale={true}
+        geojsonData={JSON.stringify(props.boundary)}
+        clipGeojsonData={JSON.stringify(props.clipGeojsonData)}
+      />
+    );
+  }
 }

--- a/src/templates/html/map/MapHTML.tsx
+++ b/src/templates/html/map/MapHTML.tsx
@@ -13,7 +13,7 @@ export function MapHTML(props: {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <script src="https://cdn.jsdelivr.net/npm/@opensystemslab/map@0.7.5"></script>
+        <script src="https://cdn.jsdelivr.net/npm/@opensystemslab/map@0.7.9"></script>
         <title>PlanX Submission Boundary</title>
       </head>
       <body>
@@ -25,7 +25,9 @@ export function MapHTML(props: {
           userAction={props.userAction}
         />
         {props.userAction && (
-          <p>This PlanX user {props.userAction.toLowerCase()}.</p>
+          <p style={{ fontSize: ".7em" }}>
+            Source: PlanX user {props.userAction.toLowerCase()}.
+          </p>
         )}
       </body>
     </html>

--- a/src/templates/html/map/MapHTML.tsx
+++ b/src/templates/html/map/MapHTML.tsx
@@ -1,11 +1,12 @@
 import { css, Global } from "@emotion/react";
 import * as React from "react";
 
-import Map from "./Map";
+import Map, { DrawBoundaryUserAction } from "./Map";
 
 export function MapHTML(props: {
   geojson: object;
   boundingBox: GeoJSON.Feature;
+  userAction?: DrawBoundaryUserAction;
 }) {
   return (
     <html>
@@ -18,7 +19,14 @@ export function MapHTML(props: {
       <body>
         <Styles />
         <h1>Boundary</h1>
-        <Map boundary={props.geojson} clipGeojsonData={props.boundingBox} />
+        <Map
+          boundary={props.geojson}
+          clipGeojsonData={props.boundingBox}
+          userAction={props.userAction}
+        />
+        {props.userAction && (
+          <p>This PlanX user {props.userAction.toLowerCase()}.</p>
+        )}
       </body>
     </html>
   );

--- a/src/templates/html/map/MapHTML.tsx
+++ b/src/templates/html/map/MapHTML.tsx
@@ -24,11 +24,6 @@ export function MapHTML(props: {
           clipGeojsonData={props.boundingBox}
           userAction={props.userAction}
         />
-        {props.userAction && (
-          <p style={{ fontSize: ".7em" }}>
-            Source: PlanX user {props.userAction.toLowerCase()}.
-          </p>
-        )}
       </body>
     </html>
   );

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -7,6 +7,7 @@ import { LDCETemplate } from "./docx/LDCETemplate";
 import { LDCPTemplate } from "./docx/LDCPTemplate";
 import { applyRedactions, getString, hasValue } from "./helpers";
 import { ApplicationHTML } from "./html/application/ApplicationHTML";
+import { DrawBoundaryUserAction } from "./html/map/Map";
 import { MapHTML } from "./html/map/MapHTML";
 
 export type Template = {
@@ -86,12 +87,14 @@ export function generateApplicationHTML({
 export function generateMapHTML({
   geojson,
   boundingBox,
+  userAction,
 }: {
   geojson: object;
   boundingBox: GeoJSON.Feature;
+  userAction?: DrawBoundaryUserAction;
 }): string {
   return renderToStaticMarkup(
-    React.createElement(MapHTML, { geojson, boundingBox }),
+    React.createElement(MapHTML, { geojson, boundingBox, userAction }),
   );
 }
 

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -72,14 +72,17 @@ export const TEMPLATES: Record<string, Template> = {
 export function generateApplicationHTML({
   planXExportData,
   boundingBox,
+  userAction,
 }: {
   planXExportData: PlanXExportData[];
   boundingBox: GeoJSON.Feature;
+  userAction?: DrawBoundaryUserAction;
 }): string {
   return renderToStaticMarkup(
     React.createElement(ApplicationHTML, {
       data: planXExportData,
       boundingBox,
+      userAction,
     }),
   );
 }


### PR DESCRIPTION
Since introducing title boundaries, we should ensure that any document templates that display the boundary: 1) have proper attribution and 2) explain the action the user took to planning officers.

`Overview.html` & `Map.html` will now always show a "Source" underneath the map image, and will conditionally render the second attribution title boundary on the map if the user accepted or amended it as their location plan. 

For example:
![Screenshot from 2024-01-24 11-22-51](https://github.com/theopensystemslab/planx-core/assets/5132349/9c11d155-e7f4-424b-a0be-88d3752b1046)

![Screenshot from 2024-01-24 10-27-17](https://github.com/theopensystemslab/planx-core/assets/5132349/ba051ccf-b600-4d36-9284-93e77e5f4987)