### PR TITLE
fix: map props need to include style and buffers should be numbers

### DIFF
--- a/src/templates/html/map/Map.tsx
+++ b/src/templates/html/map/Map.tsx
@@ -29,7 +29,7 @@ declare global {
       geojsonData?: string;
       geojsonColor?: string;
       geojsonFill?: boolean;
-      geojsonBuffer?: string;
+      geojsonBuffer?: number;
       geojsonDataCopyright?: string;
       id?: string;
       clipGeojsonData?: string;
@@ -39,7 +39,7 @@ declare global {
       drawPointer?: string;
       drawType?: string;
       drawGeojsonData?: string;
-      drawGeojsonDataBuffer?: string;
+      drawGeojsonDataBuffer?: number;
       drawGeojsonDataCopyright?: string;
       zoom?: number;
       maxZoom?: number;

--- a/src/templates/html/map/Map.tsx
+++ b/src/templates/html/map/Map.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { any, string } from "zod";
 
 // Sourced from editor.planx.uk/src/@planx/components/DrawBoundary/model
 export enum DrawBoundaryUserAction {

--- a/src/templates/html/map/Map.tsx
+++ b/src/templates/html/map/Map.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { any, string } from "zod";
 
 // Sourced from editor.planx.uk/src/@planx/components/DrawBoundary/model
 export enum DrawBoundaryUserAction {
@@ -48,6 +49,7 @@ declare global {
       showMarker?: boolean;
       markerLatitude?: number;
       markerLongitude?: number;
+      style?: any;
     }
   }
 }


### PR DESCRIPTION
It failed on the `style` tag :weary: 

Also cleaning up all buffer types which we use a bit inconsistenly between numbers/strings - Lit evaluates same / smartly but TS is picky ! 
