### PR TITLE
fix: ensure boundary HTML doesn't display print dialog

### DIFF
--- a/src/templates/html/map/MapHTML.tsx
+++ b/src/templates/html/map/MapHTML.tsx
@@ -15,6 +15,14 @@ export function MapHTML(props: {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <script src="https://cdn.jsdelivr.net/npm/@opensystemslab/map@0.7.9"></script>
         <title>PlanX Submission Boundary</title>
+        <link
+          rel="stylesheet"
+          href="https://cdn.rawgit.com/Viglino/ol-ext/master/dist/ol-ext.min.css"
+        />
+        <script
+          type="text/javascript"
+          src="https://cdn.rawgit.com/Viglino/ol-ext/master/dist/ol-ext.min.js"
+        ></script>
       </head>
       <body>
         <Styles />


### PR DESCRIPTION
The MapHTML was missing these OL CDNs, while the ApplicationHTML had them. Consistently using among both generated documents means the print dialog behaves consistently ! 

Before:
![Screenshot from 2024-01-24 19-37-00](https://github.com/theopensystemslab/planx-core/assets/5132349/19a4f377-3a00-4b17-b00d-759d210d4806)

After:
![Screenshot from 2024-01-25 11-06-07](https://github.com/theopensystemslab/planx-core/assets/5132349/794333b5-a04b-4974-879f-98adaa7e146a)
