### PR TITLE
feat: Create empty `team_theme` and `team_integrations` records on team creation

### DIFF
--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -1,3 +1,4 @@
+import { GeoJsonObject } from "geojson";
 import type { GraphQLClient } from "graphql-request";
 import { gql } from "graphql-request";
 
@@ -18,6 +19,15 @@ interface RemoveMember {
 
 type PlanXEnv = "pizza" | "staging" | "production";
 
+interface CreateTeam {
+  name: string;
+  slug: string;
+  homepage: string;
+  submissionEmail?: string;
+  boundary?: GeoJsonObject;
+  referenceCode?: string;
+}
+
 export class TeamClient {
   protected client: GraphQLClient;
 
@@ -25,14 +35,7 @@ export class TeamClient {
     this.client = client;
   }
 
-  async create(args: {
-    name: string;
-    slug: string;
-    logo: string;
-    primaryColour: string;
-    homepage: string;
-    submissionEmail: string;
-  }): Promise<number> {
+  async create(args: CreateTeam): Promise<number> {
     return createTeam(this.client, args);
   }
 
@@ -104,51 +107,47 @@ export async function createTeam(
   {
     name,
     slug,
-    logo,
-    primaryColour,
     homepage,
     submissionEmail,
-  }: {
-    name: string;
-    slug: string;
-    logo: string;
-    primaryColour: string;
-    homepage: string;
-    submissionEmail: string;
-  },
+    boundary,
+    referenceCode,
+  }: CreateTeam,
 ): Promise<number> {
   const input = {
     name,
     slug,
-    theme: {
-      logo,
-      primary_colour: primaryColour,
-    },
     submissionEmail,
     settings: {
       ...defaultSettings,
       homepage,
     },
     notifyPersonalisation: defaultNotifyPersonalisation,
+    boundary,
+    referenceCode,
   };
   const response: { insert_teams_one: { id: number } } = await client.request(
     gql`
       mutation CreateTeam(
         $name: String!
         $slug: String!
-        $theme: team_themes_insert_input!
         $settings: jsonb!
-        $submissionEmail: String!
+        $submissionEmail: String
         $notifyPersonalisation: jsonb!
+        $boundary: jsonb
+        $referenceCode: String
       ) {
         insert_teams_one(
           object: {
             name: $name
             slug: $slug
-            theme: { data: $theme }
             settings: $settings
             submission_email: $submissionEmail
             notify_personalisation: $notifyPersonalisation
+            boundary: $boundary
+            reference_code: $referenceCode
+            # Create empty records for theme and integrations - these can get populated later
+            theme: { data: {} }
+            integrations: { data: {} }
           }
         ) {
           id

--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -122,8 +122,8 @@ export async function createTeam(
       homepage,
     },
     notifyPersonalisation: defaultNotifyPersonalisation,
-    boundary,
-    referenceCode,
+    ...(boundary && { boundary }),
+    ...(referenceCode && { referenceCode }),
   };
   const response: { insert_teams_one: { id: number } } = await client.request(
     gql`
@@ -143,8 +143,9 @@ export async function createTeam(
             settings: $settings
             submission_email: $submissionEmail
             notify_personalisation: $notifyPersonalisation
-            boundary: $boundary
-            reference_code: $referenceCode
+            # Fall back to default values for optional values
+            ${boundary ? "boundary: $boundary" : ""}
+            ${referenceCode ? "reference_code: $referenceCode" : ""}
             # Create empty records for theme and integrations - these can get populated later
             theme: { data: {} }
             integrations: { data: {} }


### PR DESCRIPTION
## What does this PR do?
 - Create an empty `team_integrations` record on team creation
 - Create an empty `team_theme` record on team creation
 - Update arguments for `team.create()` to better reflect what is generally available at time of creation - make submission email optional. Boundary and reference code are also optional as not all teams will be local authorities (e.g. Templates, OSL, ODP, WikiHouse)

Implemented in https://github.com/theopensystemslab/planx-team-onboarding/pull/16 and https://github.com/theopensystemslab/planx-new/pull/2720