### PR TITLE
feat: Read file details from `Passport()` class

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "lint:fix": "eslint --fix 'src/**/*.{js,ts}' && prettier -w src/**/*",
     "test": "jest",
     "test:coverage": "jest; open ./coverage/lcov-report/index.html",
+    "test:watch": "jest --watch",
     "check": "tsc --project ./tsconfig.check.json && pnpm lint",
     "postinstall": "pnpm i rimraf && pnpm build",
     "prepare": "husky install",

--- a/src/export/bops/index.ts
+++ b/src/export/bops/index.ts
@@ -354,26 +354,22 @@ export function computeBOPSParams({
   if (geojson) data.boundary_geojson = geojson;
 
   // 2. files
-  Object.entries(passport.data || {})
-    .filter(([, v]) => (v as { url: string }[] | undefined)?.[0]?.url)
-    .forEach(([key, arr]) => {
-      (arr as { url: string }[]).forEach(({ url }) => {
-        try {
-          data.files = data.files || [];
+  passport.fileDetails().forEach(({ key, url }) => {
+    try {
+      data.files = data.files || [];
 
-          data.files.push({
-            filename: url,
-            tags: extractTagsFromPassportKey(key),
-            applicant_description: extractFileDescriptionForPassportKey(
-              passport.data,
-              key,
-            ),
-          });
-        } catch (err) {
-          throw new Error(`Error formatting files: ${err}`);
-        }
+      data.files.push({
+        filename: url,
+        tags: extractTagsFromPassportKey(key),
+        applicant_description: extractFileDescriptionForPassportKey(
+          passport.data,
+          key,
+        ),
       });
-    });
+    } catch (err) {
+      throw new Error(`Error formatting files: ${err}`);
+    }
+  });
 
   // 3. constraints
   if (passport.has(["_constraints"])) {

--- a/src/export/bops/index.ts
+++ b/src/export/bops/index.ts
@@ -354,7 +354,7 @@ export function computeBOPSParams({
   if (geojson) data.boundary_geojson = geojson;
 
   // 2. files
-  passport.fileDetails().forEach(({ key, url }) => {
+  passport.files.forEach(({ key, url }) => {
     try {
       data.files = data.files || [];
 

--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -716,7 +716,7 @@ export class DigitalPlanning {
   private getFiles(): Payload["files"] {
     const files: File[] = [];
 
-    this.passport.fileDetails().forEach(({ url, key }) => {
+    this.passport.files.forEach(({ url, key }) => {
       try {
         // push a new label to an existing file
         if (files.filter((file) => file.name === url).length > 0) {

--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -716,42 +716,38 @@ export class DigitalPlanning {
   private getFiles(): Payload["files"] {
     const files: File[] = [];
 
-    Object.entries(this.passport.data)
-      .filter(([, v]) => v?.[0]?.url)
-      .forEach(([key, arr]) => {
-        (arr as { url: string }[]).forEach(({ url }) => {
-          try {
-            // push a new label to an existing file
-            if (files.filter((file) => file.name === url).length > 0) {
-              files
-                .filter((file) => file.name === url)
-                .map((file) => {
-                  file["type"].push({
-                    value: key,
-                    description: this.findDescriptionFromValue("FileType", key),
-                  } as FileType);
-                });
-            } else {
-              // add a new file
-              files.push({
-                name: url,
-                type: [
-                  {
-                    value: key,
-                    description: this.findDescriptionFromValue("FileType", key),
-                  } as FileType,
-                ],
-                description: extractFileDescriptionForPassportKey(
-                  this.passport.data,
-                  key,
-                ),
-              });
-            }
-          } catch (err) {
-            throw new Error(`Error formatting files: ${err}`);
-          }
-        });
-      });
+    this.passport.fileDetails().forEach(({ url, key }) => {
+      try {
+        // push a new label to an existing file
+        if (files.filter((file) => file.name === url).length > 0) {
+          files
+            .filter((file) => file.name === url)
+            .map((file) => {
+              file["type"].push({
+                value: key,
+                description: this.findDescriptionFromValue("FileType", key),
+              } as FileType);
+            });
+        } else {
+          // add a new file
+          files.push({
+            name: url,
+            type: [
+              {
+                value: key,
+                description: this.findDescriptionFromValue("FileType", key),
+              } as FileType,
+            ],
+            description: extractFileDescriptionForPassportKey(
+              this.passport.data,
+              key,
+            ),
+          });
+        }
+      } catch (err) {
+        throw new Error(`Error formatting files: ${err}`);
+      }
+    });
 
     return files;
   }

--- a/src/export/oneApp/model.ts
+++ b/src/export/oneApp/model.ts
@@ -314,7 +314,7 @@ export class OneAppPayload {
   }
 
   private getUserUploadedFiles(): Partial<FileAttachment>[] {
-    return this.passport.files().map((file) => {
+    return this.passport.fileURLs().map((file) => {
       const uniqueFilename = decodeURIComponent(
         file.split("/").slice(-2).join("-"),
       );

--- a/src/export/oneApp/model.ts
+++ b/src/export/oneApp/model.ts
@@ -314,7 +314,7 @@ export class OneAppPayload {
   }
 
   private getUserUploadedFiles(): Partial<FileAttachment>[] {
-    return this.passport.fileURLs().map((file) => {
+    return this.passport.getFileURLs().map((file) => {
       const uniqueFilename = decodeURIComponent(
         file.split("/").slice(-2).join("-"),
       );

--- a/src/models/passport/passport.test.ts
+++ b/src/models/passport/passport.test.ts
@@ -34,8 +34,9 @@ describe("Passport", () => {
       const result = passport.getFileURLs();
       expect(result).toHaveLength(1);
       expect(result).toEqual([
-        (singleFileQuestion.data!["elevations.existing"] as QuestionWithFiles)[0]
-          .url,
+        (
+          singleFileQuestion.data!["elevations.existing"] as QuestionWithFiles
+        )[0].url,
       ]);
     });
 
@@ -45,10 +46,14 @@ describe("Passport", () => {
       expect(result).toHaveLength(2);
       expect(result).toEqual([
         (
-          multipleFileQuestions.data!["elevations.existing"] as QuestionWithFiles
+          multipleFileQuestions.data![
+            "elevations.existing"
+          ] as QuestionWithFiles
         )[0].url,
         (
-          multipleFileQuestions.data!["elevations.proposed"] as QuestionWithFiles
+          multipleFileQuestions.data![
+            "elevations.proposed"
+          ] as QuestionWithFiles
         )[0].url,
       ]);
     });

--- a/src/models/passport/passport.test.ts
+++ b/src/models/passport/passport.test.ts
@@ -1,15 +1,11 @@
 import { Passport as IPassport } from "../../types";
-import { Passport } from ".";
+import { Passport, QuestionWithFiles } from ".";
 import {
   multipleFileQuestions,
   multipleFilesMultipleQuestions,
   noFiles,
   singleFileQuestion,
 } from "./mocks";
-
-type ArrayWithURLProp = Array<{
-  url: string;
-}>;
 
 describe("Passport", () => {
   describe("constructor", () => {
@@ -27,75 +23,75 @@ describe("Passport", () => {
     });
   });
 
-  describe("files() method", () => {
+  describe("fileURLs() method", () => {
     it("handles Passport without files", () => {
       const passport = new Passport(noFiles);
-      expect(passport.files()).toEqual([]);
+      expect(passport.fileURLs()).toEqual([]);
     });
 
     it("handles Passport with a single file question", () => {
       const passport = new Passport(singleFileQuestion);
-      const result = passport.files();
+      const result = passport.fileURLs();
       expect(result).toHaveLength(1);
       expect(result).toEqual([
-        (singleFileQuestion.data!["elevations.existing"] as ArrayWithURLProp)[0]
+        (singleFileQuestion.data!["elevations.existing"] as QuestionWithFiles)[0]
           .url,
       ]);
     });
 
     it("handles Passport with multiple file questions", () => {
       const passport = new Passport(multipleFileQuestions);
-      const result = passport.files();
+      const result = passport.fileURLs();
       expect(result).toHaveLength(2);
       expect(result).toEqual([
         (
-          multipleFileQuestions.data!["elevations.existing"] as ArrayWithURLProp
+          multipleFileQuestions.data!["elevations.existing"] as QuestionWithFiles
         )[0].url,
         (
-          multipleFileQuestions.data!["elevations.proposed"] as ArrayWithURLProp
+          multipleFileQuestions.data!["elevations.proposed"] as QuestionWithFiles
         )[0].url,
       ]);
     });
 
     it("handles Passports with multiple files, across multiple questions", () => {
       const passport = new Passport(multipleFilesMultipleQuestions);
-      const result = passport.files();
+      const result = passport.fileURLs();
       expect(result).toHaveLength(7);
       expect(result).toEqual([
         (
           multipleFilesMultipleQuestions.data![
             "elevations.existing"
-          ] as ArrayWithURLProp
+          ] as QuestionWithFiles
         )[0].url,
         (
           multipleFilesMultipleQuestions.data![
             "elevations.existing"
-          ] as ArrayWithURLProp
+          ] as QuestionWithFiles
         )[1].url,
         (
           multipleFilesMultipleQuestions.data![
             "elevations.proposed"
-          ] as ArrayWithURLProp
+          ] as QuestionWithFiles
         )[0].url,
         (
           multipleFilesMultipleQuestions.data![
             "sitePlan.existing"
-          ] as ArrayWithURLProp
+          ] as QuestionWithFiles
         )[0].url,
         (
           multipleFilesMultipleQuestions.data![
             "sitePlan.existing"
-          ] as ArrayWithURLProp
+          ] as QuestionWithFiles
         )[1].url,
         (
           multipleFilesMultipleQuestions.data![
             "sitePlan.existing"
-          ] as ArrayWithURLProp
+          ] as QuestionWithFiles
         )[2].url,
         (
           multipleFilesMultipleQuestions.data![
             "sitePlan.proposed"
-          ] as ArrayWithURLProp
+          ] as QuestionWithFiles
         )[0].url,
       ]);
     });

--- a/src/models/passport/passport.test.ts
+++ b/src/models/passport/passport.test.ts
@@ -26,12 +26,12 @@ describe("Passport", () => {
   describe("fileURLs() method", () => {
     it("handles Passport without files", () => {
       const passport = new Passport(noFiles);
-      expect(passport.fileURLs()).toEqual([]);
+      expect(passport.getFileURLs()).toEqual([]);
     });
 
     it("handles Passport with a single file question", () => {
       const passport = new Passport(singleFileQuestion);
-      const result = passport.fileURLs();
+      const result = passport.getFileURLs();
       expect(result).toHaveLength(1);
       expect(result).toEqual([
         (singleFileQuestion.data!["elevations.existing"] as QuestionWithFiles)[0]
@@ -41,7 +41,7 @@ describe("Passport", () => {
 
     it("handles Passport with multiple file questions", () => {
       const passport = new Passport(multipleFileQuestions);
-      const result = passport.fileURLs();
+      const result = passport.getFileURLs();
       expect(result).toHaveLength(2);
       expect(result).toEqual([
         (
@@ -55,7 +55,7 @@ describe("Passport", () => {
 
     it("handles Passports with multiple files, across multiple questions", () => {
       const passport = new Passport(multipleFilesMultipleQuestions);
-      const result = passport.fileURLs();
+      const result = passport.getFileURLs();
       expect(result).toHaveLength(7);
       expect(result).toEqual([
         (

--- a/src/models/passport/passport.ts
+++ b/src/models/passport/passport.ts
@@ -1,6 +1,6 @@
 import { get as getByKeyPath, has } from "lodash";
 
-import { ServiceFiles } from "../../export/digitalPlanning/schema/types";
+// import { RequestedFiles } from "../../export/digitalPlanning/schema/types";
 import type {
   DataObject,
   KeyPath,
@@ -15,7 +15,8 @@ type PlanXFileCondition =
   | "RecommendedIf"
   | "NotRequired";
 
-type ODPSchemaFileCondition = keyof ServiceFiles;
+// type ODPSchemaFileCondition = keyof RequestedFiles;
+type ODPSchemaFileCondition = "required" | "recommended" | "optional";
 
 const FILE_CONDITION_MAP: Record<PlanXFileCondition, ODPSchemaFileCondition> = {
   AlwaysRequired: "required",

--- a/src/models/passport/passport.ts
+++ b/src/models/passport/passport.ts
@@ -53,13 +53,15 @@ export type QuestionWithFiles = FileUploadQuestion | FileUploadAndLabelQuestion;
 
 export class Passport {
   data: DataObject;
+  files: FileDetails[];
 
   constructor(passport: IPassport) {
     if (!passport.data) throw new Error("passport does not contain any data");
     this.data = passport.data;
+    this.files = this.getFiles();
   }
 
-  fileDetails(): FileDetails[] {
+  private getFiles(): FileDetails[] {
     const isFileUploadQuestion = (
       entry: [string, Value | undefined],
     ): entry is [string, QuestionWithFiles[]] => {
@@ -71,7 +73,7 @@ export class Passport {
       question: QuestionWithFiles,
     ): question is FileUploadAndLabelQuestion => has(question?.[0], "rule");
 
-    const getFileDetails = ([key, questionWithFiles]: [
+    const buildFileDetails = ([key, questionWithFiles]: [
       string,
       QuestionWithFiles[],
     ]): FileDetails[] =>
@@ -85,13 +87,13 @@ export class Passport {
 
     const fileDetails = Object.entries(this.data)
       .filter(isFileUploadQuestion)
-      .flatMap(getFileDetails);
+      .flatMap(buildFileDetails);
 
     return fileDetails;
   }
 
-  fileURLs(): string[] {
-    return this.fileDetails().map((file) => file.url);
+  getFileURLs(): string[] {
+    return this.files.map((file) => file.url);
   }
 
   has(path: KeyPath): boolean {


### PR DESCRIPTION
## What does this PR do?
- Uses a single method to read files from the passport
- Quick refactor before working on the wider file-type changes to add requested files to the ODP schema payload