### PR TITLE
feat: Add `metadata.service.files` to DigitalPlanning payload 

### DIFF
--- a/src/export/digitalPlanning/model.test.ts
+++ b/src/export/digitalPlanning/model.test.ts
@@ -189,26 +189,8 @@ describe("DigitalPlanning", () => {
     it("returns _requestedFiles from the passport if present", () => {
       const mock = mockSessions[0];
       const mockRequestedFiles = {
-        required: [
-          {
-            value: "photographs.proposed",
-            description: "Photographs - proposed",
-          },
-          {
-            value: "sitePlan.proposed",
-            description: "Site plan - proposed",
-          },
-        ],
-        recommended: [
-          {
-            value: "otherEvidence",
-            description: "Other - evidence or correspondence",
-          },
-          {
-            value: "constructionInvoice",
-            description: "Construction invoice",
-          },
-        ],
+        required: ["photographs.proposed", "sitePlan.proposed"],
+        recommended: ["otherEvidence", "constructionInvoice"],
         optional: [],
       };
 
@@ -230,8 +212,32 @@ describe("DigitalPlanning", () => {
       expect(payload.metadata).toHaveProperty("service");
       // @ts-ignore
       expect(payload.metadata.service!).toHaveProperty("files");
+
+      const enrichedFiles = {
+        required: [
+          {
+            description: "Photographs - proposed",
+            value: "photographs.proposed",
+          },
+          {
+            description: "Site plan - proposed",
+            value: "sitePlan.proposed",
+          },
+        ],
+        recommended: [
+          {
+            description: "Other - evidence or correspondence",
+            value: "otherEvidence",
+          },
+          {
+            description: "Construction invoice",
+            value: "constructionInvoice",
+          },
+        ],
+        optional: [],
+      };
       // @ts-ignore
-      expect(payload.metadata.service!.files!).toEqual(mockRequestedFiles);
+      expect(payload.metadata.service!.files!).toEqual(enrichedFiles);
     });
 
     it("returns an empty default if _requestedFiles is not present", () => {

--- a/src/export/digitalPlanning/model.test.ts
+++ b/src/export/digitalPlanning/model.test.ts
@@ -184,4 +184,79 @@ describe("DigitalPlanning", () => {
       });
     });
   });
+
+  describe("getRequestedFiles", () => {
+    it("returns _requestedFiles from the passport if present", () => {
+      const mock = mockSessions[0];
+      const mockRequestedFiles = {
+        required: [
+          {
+            value: "photographs.proposed",
+            description: "Photographs - proposed",
+          },
+          {
+            value: "sitePlan.proposed",
+            description: "Site plan - proposed",
+          },
+        ],
+        recommended: [
+          {
+            value: "otherEvidence",
+            description: "Other - evidence or correspondence",
+          },
+          {
+            value: "constructionInvoice",
+            description: "Construction invoice",
+          },
+        ],
+        optional: [],
+      };
+
+      const instance = new DigitalPlanning({
+        sessionId: "c06eebb7-6201-4bc0-9fe7-ec5d7a1c0797",
+        passport: new Passport({
+          data: {
+            ...mockLDCPSession.passport,
+            _requestedFiles: mockRequestedFiles,
+          },
+        }),
+        breadcrumbs: mock.breadcrumbs,
+        flow: mock.flow,
+        metadata: mock.metadata,
+      });
+
+      const payload = instance.getPayload();
+
+      expect(payload.metadata).toHaveProperty("service");
+      // @ts-ignore
+      expect(payload.metadata.service!).toHaveProperty("files");
+      // @ts-ignore
+      expect(payload.metadata.service!.files!).toEqual(mockRequestedFiles);
+    });
+
+    it("returns an empty default if _requestedFiles is not present", () => {
+      const mock = mockSessions[0];
+      const defaultRequestedFiles = {
+        required: [],
+        recommended: [],
+        optional: [],
+      };
+
+      const instance = new DigitalPlanning({
+        sessionId: "c06eebb7-6201-4bc0-9fe7-ec5d7a1c0797",
+        passport: mock.passport,
+        breadcrumbs: mock.breadcrumbs,
+        flow: mock.flow,
+        metadata: mock.metadata,
+      });
+
+      const payload = instance.getPayload();
+
+      expect(payload.metadata).toHaveProperty("service");
+      // @ts-ignore
+      expect(payload.metadata.service!).toHaveProperty("files");
+      // @ts-ignore
+      expect(payload.metadata.service!.files!).toEqual(defaultRequestedFiles);
+    });
+  });
 });

--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -29,6 +29,7 @@ import {
   PlanXMetadata,
   ProjectType,
   Proposal,
+  RequestedFiles,
   SiteContact,
   UKProperty,
 } from "./schema/types";
@@ -777,6 +778,13 @@ export class DigitalPlanning {
     return responses as Payload["responses"];
   }
 
+  private getRequestedFiles(): RequestedFiles {
+    const requestedFiles = this.passport.any<RequestedFiles>([
+      "_requestedFiles",
+    ]);
+    return requestedFiles || { required: [], recommended: [], optional: [] };
+  }
+
   private getMetadata(): Payload["metadata"] {
     return {
       id: this.sessionId,
@@ -786,6 +794,7 @@ export class DigitalPlanning {
       service: {
         flowId: this.metadata.flow.id,
         url: `https://www.editor.planx.uk/${this.metadata.flow.team.slug}/${this.metadata.flow.slug}/preview`,
+        files: this.getRequestedFiles(),
       },
       schema: `https://theopensystemslab.github.io/digital-planning-data-schemas/${jsonSchema["$id"]}/schema.json`,
     } as PlanXMetadata;

--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -779,10 +779,33 @@ export class DigitalPlanning {
   }
 
   private getRequestedFiles(): RequestedFiles {
-    const requestedFiles = this.passport.any<RequestedFiles>([
+    interface PassportRequestedFiles {
+      required: string[];
+      recommended: string[];
+      optional: string[];
+    }
+
+    const passportRequestedFiles = this.passport.any<PassportRequestedFiles>([
       "_requestedFiles",
     ]);
-    return requestedFiles || { required: [], recommended: [], optional: [] };
+
+    if (!passportRequestedFiles)
+      return { required: [], recommended: [], optional: [] };
+
+    const buildFileTypeFromKey = (key: string) =>
+      ({
+        value: key,
+        description: this.findDescriptionFromValue("FileType", key),
+      }) as FileType;
+
+    const { required, recommended, optional } = passportRequestedFiles;
+    const requestedFiles = {
+      required: required.map(buildFileTypeFromKey),
+      recommended: recommended.map(buildFileTypeFromKey),
+      optional: optional.map(buildFileTypeFromKey),
+    };
+
+    return requestedFiles;
   }
 
   private getMetadata(): Payload["metadata"] {

--- a/src/models/passport/passport.ts
+++ b/src/models/passport/passport.ts
@@ -76,15 +76,9 @@ export class Passport {
     return +(this.strings(path)[0] || 0);
   }
 
-  any(path: KeyPath): unknown {
+  any<T>(path: KeyPath): T | undefined {
     if (!this.has(path)) return;
-    return get({ data: this.data, path })!;
-  }
-
-  generic<T>(path: string): T | undefined {
-    const keyPath = path.split(".");
-    if (!this.has(keyPath)) return;
-    return getGeneric<T>({ data: this.data, path: keyPath }) as T;
+    return get({ data: this.data, path })! as T;
   }
 }
 
@@ -124,15 +118,4 @@ function get({
     return output as DataObject;
   }
   ((_x: never) => new Error("Value should always be handled"))(output);
-}
-
-function getGeneric<T>({
-  data,
-  path,
-}: {
-  data: DataObject;
-  path: KeyPath;
-}): T | undefined {
-  const output: Value = getByKeyPath(data, path);
-  return output ? undefined : (output as T);
 }


### PR DESCRIPTION
Cherry picked from https://github.com/theopensystemslab/planx-core/pull/291 to avoid rebasing too much!

## What does this PR do?
- Adds and populates `metadata.service.file` to Digital Planning payload
- Adds a few test cases, certainly scope for more here!