### PR TITLE
fix: update `SiteContact` passport variables mapping

### DIFF
--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -285,10 +285,13 @@ export class DigitalPlanning {
     if (this.passport.data?.["applicant.siteContact"]?.[0] === "other") {
       return {
         role: "other",
-        name: this.passport.data?.["applicant.siteContact.name"]?.[0],
+        name:
+          this.passport.data?.["applicant.siteContact.name.first"] +
+          " " +
+          this.passport.data?.["applicant.siteContact.name.last"],
         email: this.passport.data?.["applicant.siteContact.email"] as string,
         phone: this.passport.data?.[
-          "applicant.siteContact.telephone"
+          "applicant.siteContact.phone.primary"
         ] as string,
       };
     } else {


### PR DESCRIPTION
Fixes schema validation error thrown here: https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1707739712194959

These admin endpoints are useful in troubleshooting / id'ing the error:
https://api.editor.planx.dev/admin/session/dba890b5-793c-41ba-b7f1-8650788ff3dc/digital-planning-application
https://api.editor.planx.dev/admin/session/dba890b5-793c-41ba-b7f1-8650788ff3dc/summary

This one was a passport mapping error on our side:
- When the site contact is _not_ the applicant, we were previously looking for single text input `applicant.siteContact.name`
- But the flow uses a contact input which writes `applicant.siteContact.name.first` & `applicant.siteContact.name.last`