### PR TITLE
fix: unskip schema tests

### DIFF
--- a/src/export/digitalPlanning/model.test.ts
+++ b/src/export/digitalPlanning/model.test.ts
@@ -91,7 +91,7 @@ const mockParams = {
 describe("DigitalPlanning", () => {
   describe("getPayload", () => {
     mockSessions.forEach((mock) => {
-      it.skip(`should return valid payload (${mock.name})`, () => {
+      it(`should return valid payload (${mock.name})`, () => {
         const instance = new DigitalPlanning({
           sessionId: "c06eebb7-6201-4bc0-9fe7-ec5d7a1c0797",
           passport: mock.passport,


### PR DESCRIPTION
These were temporarily skipped while sequencing merges about document-type changes and we forgot to re-enable ! 