### PR TITLE
feat: include the ODP Schema as "application.json" in files sent to Uniform

### DIFF
--- a/src/export/oneApp/OneApp.test.ts
+++ b/src/export/oneApp/OneApp.test.ts
@@ -601,6 +601,10 @@ describe("File handling", () => {
         "common:Reference": "Other",
       },
       {
+        "common:FileName": "application.json",
+        "common:Reference": "Other",
+      },
+      {
         "common:Identifier": "N10049",
         "common:FileName": "proposal.xml",
         "common:Reference": "Schema XML File",

--- a/src/export/oneApp/model.ts
+++ b/src/export/oneApp/model.ts
@@ -288,6 +288,9 @@ export class OneAppPayload {
         "common:FileName": "application.csv",
       },
       {
+        "common:FileName": "application.json",
+      },
+      {
         "common:FileName": "Overview.htm",
       },
       {


### PR DESCRIPTION
Related to https://github.com/theopensystemslab/planx-new/pull/2804

Rather than making this an optional argument on the `buildSubmissionExportZip()` method like `includeDigitalPlanningSchemaJSON` - we can just include by default for supported application types (Uniform = always LDC) which will give councils more flexibility (eg retrieve the JSON from DMS rather than email inbox; not have to configure a service to send to all three possible destinations) and communicates to Idox that we're ready/able to be sending this new data format regardless of Nexus.

Once this is approved and merged to `main` along with 2804, I'll submit a test LDC on staging and get a council PO to confirm it can be received correctly via DMS and doesn't break before going to production.