### PR TITLE
Revert "feat: include the ODP Schema as "application.json" in files sent to Uniform"

### DIFF
--- a/src/export/oneApp/OneApp.test.ts
+++ b/src/export/oneApp/OneApp.test.ts
@@ -601,10 +601,6 @@ describe("File handling", () => {
         "common:Reference": "Other",
       },
       {
-        "common:FileName": "application.json",
-        "common:Reference": "Other",
-      },
-      {
         "common:Identifier": "N10049",
         "common:FileName": "proposal.xml",
         "common:Reference": "Schema XML File",

--- a/src/export/oneApp/model.ts
+++ b/src/export/oneApp/model.ts
@@ -288,9 +288,6 @@ export class OneAppPayload {
         "common:FileName": "application.csv",
       },
       {
-        "common:FileName": "application.json",
-      },
-      {
         "common:FileName": "Overview.htm",
       },
       {


### PR DESCRIPTION
Reverts theopensystemslab/planx-core#309

Doesn't look hopeful that DMS will accept a JSON, and found out most folks' staging envs were either turned off or inaccessible and this isn't a necessary change, so probably not worth the test trouble.