### PR TITLE
chore: update any Editor `/preview` URLs to `/published`

### DIFF
--- a/src/export/bops/mocks/payload.ts
+++ b/src/export/bops/mocks/payload.ts
@@ -339,7 +339,7 @@ export const mockExpectedBOPSPayload = {
           reference: "969b912c-f196-4ec6-ac73-133f2a516f60",
           payment_id: "34qqn82kdmc7qaodm5a7qqovbj",
           return_url:
-            "https://editor.planx.uk/lambeth/apply-for-a-lawful-development-certificate/preview?sessionId=969b912c-f196-4ec6-ac73-133f2a516f60&email=test%40opensystemslab.io",
+            "https://editor.planx.uk/lambeth/apply-for-a-lawful-development-certificate/published?sessionId=969b912c-f196-4ec6-ac73-133f2a516f60&email=test%40opensystemslab.io",
           description: "New application",
           created_date: "2023-04-27T10:17:44.924Z",
           refund_summary: {
@@ -728,7 +728,7 @@ export const mockExpectedBOPSPayload = {
             reference: "969b912c-f196-4ec6-ac73-133f2a516f60",
             payment_id: "34qqn82kdmc7qaodm5a7qqovbj",
             return_url:
-              "https://editor.planx.uk/lambeth/apply-for-a-lawful-development-certificate/preview?sessionId=969b912c-f196-4ec6-ac73-133f2a516f60&email=test%40opensystemslab.io",
+              "https://editor.planx.uk/lambeth/apply-for-a-lawful-development-certificate/published?sessionId=969b912c-f196-4ec6-ac73-133f2a516f60&email=test%40opensystemslab.io",
             description: "New application",
             created_date: "2023-04-27T10:17:44.924Z",
             refund_summary: {

--- a/src/export/bops/mocks/sessionData.ts
+++ b/src/export/bops/mocks/sessionData.ts
@@ -244,7 +244,7 @@ export const mockSessionData = {
         reference: "969b912c-f196-4ec6-ac73-133f2a516f60",
         payment_id: "34qqn82kdmc7qaodm5a7qqovbj",
         return_url:
-          "https://editor.planx.uk/lambeth/apply-for-a-lawful-development-certificate/preview?sessionId=969b912c-f196-4ec6-ac73-133f2a516f60&email=test%40opensystemslab.io",
+          "https://editor.planx.uk/lambeth/apply-for-a-lawful-development-certificate/published?sessionId=969b912c-f196-4ec6-ac73-133f2a516f60&email=test%40opensystemslab.io",
         description: "New application",
         created_date: "2023-04-27T10:17:44.924Z",
         refund_summary: {
@@ -633,7 +633,7 @@ export const mockSessionData = {
           reference: "969b912c-f196-4ec6-ac73-133f2a516f60",
           payment_id: "34qqn82kdmc7qaodm5a7qqovbj",
           return_url:
-            "https://editor.planx.uk/lambeth/apply-for-a-lawful-development-certificate/preview?sessionId=969b912c-f196-4ec6-ac73-133f2a516f60&email=test%40opensystemslab.io",
+            "https://editor.planx.uk/lambeth/apply-for-a-lawful-development-certificate/published?sessionId=969b912c-f196-4ec6-ac73-133f2a516f60&email=test%40opensystemslab.io",
           description: "New application",
           created_date: "2023-04-27T10:17:44.924Z",
           refund_summary: {
@@ -1063,7 +1063,7 @@ export const mockSessionData = {
     reference: "969b912c-f196-4ec6-ac73-133f2a516f60",
     payment_id: "34qqn82kdmc7qaodm5a7qqovbj",
     return_url:
-      "https://editor.planx.uk/lambeth/apply-for-a-lawful-development-certificate/preview?sessionId=969b912c-f196-4ec6-ac73-133f2a516f60&email=test%40opensystemslab.io",
+      "https://editor.planx.uk/lambeth/apply-for-a-lawful-development-certificate/published?sessionId=969b912c-f196-4ec6-ac73-133f2a516f60&email=test%40opensystemslab.io",
     description: "New application",
     created_date: "2023-04-27T10:17:44.924Z",
     refund_summary: {

--- a/src/export/digitalPlanning/mocks/lawfulDevelopmentCertificate.ts
+++ b/src/export/digitalPlanning/mocks/lawfulDevelopmentCertificate.ts
@@ -1797,7 +1797,7 @@ export const mockLDCESession = {
       reference: "95f90e21-93f5-4761-90b3-815c673e041f",
       payment_id: "50h1fi7l9eo4c9fa7jm1avs3ag",
       return_url:
-        "https://editor.planx.dev/buckinghamshire/apply-for-a-lawful-development-certificate/preview?sessionId=95f90e21-93f5-4761-90b3-815c673e041f&email=example%40example.com",
+        "https://editor.planx.dev/buckinghamshire/apply-for-a-lawful-development-certificate/published?sessionId=95f90e21-93f5-4761-90b3-815c673e041f&email=example%40example.com",
       description: "New application",
       created_date: "2023-09-01T06:46:41.524Z",
       refund_summary: {
@@ -3878,7 +3878,7 @@ export const mockLDCESession = {
           reference: "95f90e21-93f5-4761-90b3-815c673e041f",
           payment_id: "50h1fi7l9eo4c9fa7jm1avs3ag",
           return_url:
-            "https://editor.planx.dev/buckinghamshire/apply-for-a-lawful-development-certificate/preview?sessionId=95f90e21-93f5-4761-90b3-815c673e041f&email=example%40example.com",
+            "https://editor.planx.dev/buckinghamshire/apply-for-a-lawful-development-certificate/published?sessionId=95f90e21-93f5-4761-90b3-815c673e041f&email=example%40example.com",
           description: "New application",
           created_date: "2023-09-01T06:46:41.524Z",
           refund_summary: {

--- a/src/export/digitalPlanning/mocks/planningPermission.ts
+++ b/src/export/digitalPlanning/mocks/planningPermission.ts
@@ -997,7 +997,7 @@ export const mockPlanningPermissionSession = {
       reference: "81bcaa0f-baf5-4573-ba0a-ea868c573faf",
       payment_id: "5673suh81flgoh8idng0jjhq8g",
       return_url:
-        "https://editor.planx.dev/lambeth/apply-for-planning-permission/preview?sessionId=81bcaa0f-baf5-4573-ba0a-ea868c573faf&email=example%40example.com",
+        "https://editor.planx.dev/lambeth/apply-for-planning-permission/published?sessionId=81bcaa0f-baf5-4573-ba0a-ea868c573faf&email=example%40example.com",
       description: "New application",
       created_date: "2023-08-31T17:50:43.647Z",
       refund_summary: {
@@ -2296,7 +2296,7 @@ export const mockPlanningPermissionSession = {
           reference: "81bcaa0f-baf5-4573-ba0a-ea868c573faf",
           payment_id: "5673suh81flgoh8idng0jjhq8g",
           return_url:
-            "https://editor.planx.dev/lambeth/apply-for-planning-permission/preview?sessionId=81bcaa0f-baf5-4573-ba0a-ea868c573faf&email=example%40example.com",
+            "https://editor.planx.dev/lambeth/apply-for-planning-permission/published?sessionId=81bcaa0f-baf5-4573-ba0a-ea868c573faf&email=example%40example.com",
           description: "New application",
           created_date: "2023-08-31T17:50:43.647Z",
           refund_summary: {

--- a/src/export/digitalPlanning/mocks/priorApproval.ts
+++ b/src/export/digitalPlanning/mocks/priorApproval.ts
@@ -947,7 +947,7 @@ export const mockPriorApprovalSession = {
       reference: "b18c301b-9d44-4c6c-8d27-5b5bf33c570b",
       payment_id: "vl3stqff6n6k6o1pq4c8p4ffa9",
       return_url:
-        "https://editor.planx.dev/southwark/apply-for-prior-approval/preview?sessionId=b18c301b-9d44-4c6c-8d27-5b5bf33c570b&email=example%40example.com",
+        "https://editor.planx.dev/southwark/apply-for-prior-approval/published?sessionId=b18c301b-9d44-4c6c-8d27-5b5bf33c570b&email=example%40example.com",
       description: "New application",
       created_date: "2023-09-02T14:55:26.281Z",
       refund_summary: {
@@ -1235,7 +1235,7 @@ export const mockPriorApprovalSession = {
           reference: "b18c301b-9d44-4c6c-8d27-5b5bf33c570b",
           payment_id: "vl3stqff6n6k6o1pq4c8p4ffa9",
           return_url:
-            "https://editor.planx.dev/southwark/apply-for-prior-approval/preview?sessionId=b18c301b-9d44-4c6c-8d27-5b5bf33c570b&email=example%40example.com",
+            "https://editor.planx.dev/southwark/apply-for-prior-approval/published?sessionId=b18c301b-9d44-4c6c-8d27-5b5bf33c570b&email=example%40example.com",
           description: "New application",
           created_date: "2023-09-02T14:55:26.281Z",
           refund_summary: {

--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -822,7 +822,7 @@ export class DigitalPlanning {
       source: "PlanX",
       service: {
         flowId: this.metadata.flow.id,
-        url: `https://www.editor.planx.uk/${this.metadata.flow.team.slug}/${this.metadata.flow.slug}/preview`,
+        url: `https://www.editor.planx.uk/${this.metadata.flow.team.slug}/${this.metadata.flow.slug}/published`,
         files: this.getRequestedFiles(),
       },
       schema: `https://theopensystemslab.github.io/digital-planning-data-schemas/${jsonSchema["$id"]}/schema.json`,


### PR DESCRIPTION
Related to https://github.com/theopensystemslab/planx-new/pull/2854

Mostly just updates to mock data here besides populating `metadata.service` URL in ODP Schema - therefore we shouldn't merge this until publishing changes are live on Planx staging/production ! 