### PR TITLE
feat: populate fee explanations in ODP Schema v0.4.1

### DIFF
--- a/src/export/digitalPlanning/model.test.ts
+++ b/src/export/digitalPlanning/model.test.ts
@@ -101,6 +101,7 @@ describe("DigitalPlanning", () => {
         });
 
         const payload = instance.getPayload();
+        console.log(payload.metadata);
 
         expect(payload).toEqual(instance.payload);
       });

--- a/src/export/digitalPlanning/model.test.ts
+++ b/src/export/digitalPlanning/model.test.ts
@@ -101,7 +101,6 @@ describe("DigitalPlanning", () => {
         });
 
         const payload = instance.getPayload();
-        console.log(payload.metadata);
 
         expect(payload).toEqual(instance.payload);
       });

--- a/src/export/digitalPlanning/schema/schema.json
+++ b/src/export/digitalPlanning/schema/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "v0.4.0",
+  "$id": "@next",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "definitions": {
@@ -1344,6 +1344,33 @@
       },
       "type": "object"
     },
+    "CalculateMetadata": {
+      "$id": "#CalculateMetadata",
+      "additionalProperties": false,
+      "description": "Metadata associated with PlanX Calculate components used to determine fees throughout a service",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "policyRefs": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "text": {
+                "type": "string"
+              },
+              "url": {
+                "$ref": "#/definitions/URL"
+              }
+            },
+            "required": ["text"],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
     "Date": {
       "format": "date",
       "type": "string"
@@ -1437,6 +1464,27 @@
         }
       },
       "required": ["features", "type"],
+      "type": "object"
+    },
+    "FeeExplanation": {
+      "$id": "#FeeExplanation",
+      "additionalProperties": false,
+      "description": "An explanation, including policy references, of the calculated and payable fees associated with this application",
+      "properties": {
+        "calculated": {
+          "items": {
+            "$ref": "#/definitions/CalculateMetadata"
+          },
+          "type": "array"
+        },
+        "payable": {
+          "items": {
+            "$ref": "#/definitions/CalculateMetadata"
+          },
+          "type": "array"
+        }
+      },
+      "required": ["calculated", "payable"],
       "type": "object"
     },
     "File": {
@@ -2697,6 +2745,21 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Viability Appraisal",
+              "type": "string"
+            },
+            "value": {
+              "const": "viabilityAppraisal",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Visualisations",
               "type": "string"
             },
@@ -3723,6 +3786,9 @@
         "service": {
           "additionalProperties": false,
           "properties": {
+            "fee": {
+              "$ref": "#/definitions/FeeExplanation"
+            },
             "files": {
               "$ref": "#/definitions/RequestedFiles"
             },
@@ -3733,7 +3799,7 @@
               "$ref": "#/definitions/URL"
             }
           },
-          "required": ["flowId", "url", "files"],
+          "required": ["flowId", "url", "files", "fee"],
           "type": "object"
         },
         "source": {
@@ -17681,7 +17747,7 @@
     "RequestedFiles": {
       "$id": "#RequestedFiles",
       "additionalProperties": false,
-      "description": "File types requested by this service. Schema[\"files\"] will be a subset of this list based on the user's journey through the service.",
+      "description": "File types requested by this service. Schema[\"files\"] will be a subset of this list based on the user's journey through the service",
       "properties": {
         "optional": {
           "items": {

--- a/src/export/digitalPlanning/schema/schema.json
+++ b/src/export/digitalPlanning/schema/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "@next",
+  "$id": "v0.4.1",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "definitions": {
@@ -203,6 +203,9 @@
       "additionalProperties": false,
       "description": "Information about this planning application",
       "properties": {
+        "CIL": {
+          "$ref": "#/definitions/CommunityInfrastructureLevy"
+        },
         "declaration": {
           "$ref": "#/definitions/ApplicationDeclaration"
         },
@@ -1316,6 +1319,9 @@
           "required": ["area"],
           "type": "object"
         },
+        "materials": {
+          "$ref": "#/definitions/Materials"
+        },
         "new": {
           "additionalProperties": false,
           "properties": {
@@ -1369,6 +1375,26 @@
           "type": "array"
         }
       },
+      "type": "object"
+    },
+    "CommunityInfrastructureLevy": {
+      "$id": "#CommunityInfrastructureLevy",
+      "additionalProperties": false,
+      "description": "Details about the Community Infrastructure Levy planning charge, if applicable",
+      "properties": {
+        "result": {
+          "enum": [
+            "exempt.annexe",
+            "exempt.extension",
+            "exempt.selfBuild",
+            "liable",
+            "relief.charity",
+            "relief.socialHousing"
+          ],
+          "type": "string"
+        }
+      },
+      "required": ["result"],
       "type": "object"
     },
     "Date": {
@@ -1511,6 +1537,21 @@
     "FileType": {
       "$id": "#FileType",
       "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Details of impact on access, roads, and rights of way",
+              "type": "string"
+            },
+            "value": {
+              "const": "accessRoadsRightsOfWayDetails",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
         {
           "additionalProperties": false,
           "properties": {
@@ -1820,6 +1861,21 @@
             },
             "value": {
               "const": "environmentalImpactAssessment",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "External materials details",
+              "type": "string"
+            },
+            "value": {
+              "const": "externalMaterialsDetails",
               "type": "string"
             }
           },
@@ -2595,6 +2651,36 @@
           "additionalProperties": false,
           "properties": {
             "description": {
+              "const": "Location of trees and hedges",
+              "type": "string"
+            },
+            "value": {
+              "const": "treeAndHedgeLocation",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Removed or pruned trees and hedges",
+              "type": "string"
+            },
+            "value": {
+              "const": "treeAndHedgeRemovedOrPruned",
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
               "const": "Tree canopy calculator",
               "type": "string"
             },
@@ -2914,6 +3000,9 @@
           },
           "required": ["area"],
           "type": "object"
+        },
+        "materials": {
+          "$ref": "#/definitions/Materials"
         },
         "new": {
           "additionalProperties": false,
@@ -3466,6 +3555,9 @@
           "required": ["site", "area"],
           "type": "object"
         },
+        "details": {
+          "$ref": "#/definitions/PropertyDetails"
+        },
         "localAuthorityDistrict": {
           "description": "Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
           "items": {
@@ -3555,6 +3647,36 @@
         "titleNumber",
         "type"
       ],
+      "type": "object"
+    },
+    "Materials": {
+      "additionalProperties": false,
+      "properties": {
+        "boundary": {
+          "type": "string"
+        },
+        "door": {
+          "type": "string"
+        },
+        "lighting": {
+          "type": "string"
+        },
+        "other": {
+          "type": "string"
+        },
+        "roof": {
+          "type": "string"
+        },
+        "surface": {
+          "type": "string"
+        },
+        "wall": {
+          "type": "string"
+        },
+        "window": {
+          "type": "string"
+        }
+      },
       "type": "object"
     },
     "Metadata": {
@@ -10627,6 +10749,17 @@
         }
       ],
       "description": "Information about the site where the works will happen"
+    },
+    "PropertyDetails": {
+      "$id": "#PropertyDetails",
+      "additionalProperties": false,
+      "description": "Details about the property as it currently exists",
+      "properties": {
+        "materials": {
+          "$ref": "#/definitions/Materials"
+        }
+      },
+      "type": "object"
     },
     "PropertyType": {
       "$id": "#PropertyType",
@@ -18346,6 +18479,9 @@
           },
           "required": ["site", "area"],
           "type": "object"
+        },
+        "details": {
+          "$ref": "#/definitions/PropertyDetails"
         },
         "localAuthorityDistrict": {
           "description": "Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",

--- a/src/export/digitalPlanning/schema/types.d.ts
+++ b/src/export/digitalPlanning/schema/types.d.ts
@@ -4059,6 +4059,10 @@ export type ProjectType =
  */
 export type FileType =
   | {
+      description: "Details of impact on access, roads, and rights of way";
+      value: "accessRoadsRightsOfWayDetails";
+    }
+  | {
       description: "Affordable housing statement";
       value: "affordableHousingStatement";
     }
@@ -4141,6 +4145,10 @@ export type FileType =
   | {
       description: "Environmental Impact Assessment (EIA)";
       value: "environmentalImpactAssessment";
+    }
+  | {
+      description: "External materials details";
+      value: "externalMaterialsDetails";
     }
   | {
       description: "Fire safety report";
@@ -4345,6 +4353,14 @@ export type FileType =
   | {
       description: "Travel plan";
       value: "travelPlan";
+    }
+  | {
+      description: "Location of trees and hedges";
+      value: "treeAndHedgeLocation";
+    }
+  | {
+      description: "Removed or pruned trees and hedges";
+      value: "treeAndHedgeRemovedOrPruned";
     }
   | {
       description: "Tree canopy calculator";
@@ -4668,10 +4684,23 @@ export interface Agent {
  * Information about this planning application
  */
 export interface Application {
+  CIL?: CommunityInfrastructureLevy;
   declaration: ApplicationDeclaration;
   fee: ApplicationFee;
   preApp?: PreApplication;
   type: ApplicationType;
+}
+/**
+ * Details about the Community Infrastructure Levy planning charge, if applicable
+ */
+export interface CommunityInfrastructureLevy {
+  result:
+    | "exempt.annexe"
+    | "exempt.extension"
+    | "exempt.selfBuild"
+    | "liable"
+    | "relief.charity"
+    | "relief.socialHousing";
 }
 /**
  * Declarations about the accuracy of this application and any personal connections to the receiving authority
@@ -4731,6 +4760,7 @@ export interface UKProperty {
     area: Area;
     site: GeoJSON;
   };
+  details?: PropertyDetails;
   /**
    * Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district
    */
@@ -5013,6 +5043,22 @@ export interface Feature3CGeometry2CGeoJsonProperties3E {
   type: "Feature";
 }
 /**
+ * Details about the property as it currently exists
+ */
+export interface PropertyDetails {
+  materials?: Materials;
+}
+export interface Materials {
+  boundary?: string;
+  door?: string;
+  lighting?: string;
+  other?: string;
+  roof?: string;
+  surface?: string;
+  wall?: string;
+  window?: string;
+}
+/**
  * Property details for sites within the Greater London Authority (GLA) area
  */
 export interface LondonProperty {
@@ -5025,6 +5071,7 @@ export interface LondonProperty {
     area: Area;
     site: GeoJSON;
   };
+  details?: PropertyDetails;
   /**
    * Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district
    */
@@ -5087,6 +5134,7 @@ export interface BaseDetails {
   extend?: {
     area: Area;
   };
+  materials?: Materials;
   new?: {
     area: Area;
     count?: {
@@ -5103,6 +5151,7 @@ export interface LondonDetails {
   extend?: {
     area: Area;
   };
+  materials?: Materials;
   new?: {
     area: Area;
     count?: {

--- a/src/export/digitalPlanning/schema/types.d.ts
+++ b/src/export/digitalPlanning/schema/types.d.ts
@@ -4387,6 +4387,10 @@ export type FileType =
       value: "ventilationStatement";
     }
   | {
+      description: "Viability Appraisal";
+      value: "viabilityAppraisal";
+    }
+  | {
       description: "Visualisations";
       value: "visualisations";
     }
@@ -5293,6 +5297,7 @@ export interface PlanXMetadata {
   organisation: string;
   schema: URL;
   service: {
+    fee: FeeExplanation;
     files: RequestedFiles;
     flowId: UUID;
     url: URL;
@@ -5301,7 +5306,24 @@ export interface PlanXMetadata {
   submittedAt: DateTime;
 }
 /**
- * File types requested by this service. Schema["files"] will be a subset of this list based on the user's journey through the service.
+ * An explanation, including policy references, of the calculated and payable fees associated with this application
+ */
+export interface FeeExplanation {
+  calculated: CalculateMetadata[];
+  payable: CalculateMetadata[];
+}
+/**
+ * Metadata associated with PlanX Calculate components used to determine fees throughout a service
+ */
+export interface CalculateMetadata {
+  description?: string;
+  policyRefs?: {
+    text: string;
+    url?: URL;
+  }[];
+}
+/**
+ * File types requested by this service. Schema["files"] will be a subset of this list based on the user's journey through the service
  */
 export interface RequestedFiles {
   optional: FileType[];


### PR DESCRIPTION
Relies on https://github.com/theopensystemslab/digital-planning-data-schemas/pull/124

Parses the Calculate "help text" from applicable nodes and adds to the Planx service metadata for a given payload.