### PR TITLE
fix: adjust `Session` type to include `flow.id` & `flow.slug`

### DIFF
--- a/src/export/digitalPlanning/index.ts
+++ b/src/export/digitalPlanning/index.ts
@@ -16,7 +16,7 @@ export async function generateDigitalPlanningPayload({
     throw new Error(`Data missing for session ${sessionId}`);
 
   const flow = await findPublishedFlowBySessionId(client, sessionId);
-  if (!flow) throw new Error(`Cannot get published flow ${session.flowId}`);
+  if (!flow) throw new Error(`Cannot get published flow ${session.flow.id}`);
 
   const metadata = await getSessionMetadata(client, sessionId);
   if (!metadata)

--- a/src/export/index.ts
+++ b/src/export/index.ts
@@ -99,9 +99,9 @@ export async function generateBOPSPayload({
     if (!session) throw new Error(`Cannot find session ${sessionId}`);
 
     const flow = await findPublishedFlowBySessionId(client, sessionId);
-    if (!flow) throw new Error(`Cannot get published flow ${session.flowId}.`);
+    if (!flow) throw new Error(`Cannot get published flow ${session.flow.id}.`);
 
-    const flowName = await getFlowName(client, session.flowId);
+    const flowName = await getFlowName(client, session.flow.id);
     const { breadcrumbs, passport } = session.data;
 
     if (isRedacted) {

--- a/src/export/oneApp/mocks/session.ts
+++ b/src/export/oneApp/mocks/session.ts
@@ -2,13 +2,16 @@ import { Session } from "../../../types";
 import { mockProposedLDCPassportData } from "./passport";
 
 export const mockSession: Session = {
+  id: "session123",
   data: {
-    id: "abc123",
+    id: "flow123",
     passport: {
       data: mockProposedLDCPassportData,
     },
     breadcrumbs: {},
   },
-  flowId: "flow123",
-  id: "session123",
+  flow: {
+    id: "flow123",
+    slug: "apply-for-something",
+  },
 };

--- a/src/requests/payment-request.test.ts
+++ b/src/requests/payment-request.test.ts
@@ -5,11 +5,14 @@ describe("extractSessionPreviewData", () => {
   test("passport data must be available", () => {
     const emptySession: Session = {
       id: "abc",
-      flowId: "abc",
       data: {
-        id: "abc",
+        id: "flow-abc",
         passport: { data: {} },
         breadcrumbs: {},
+      },
+      flow: {
+        id: "flow-abc",
+        slug: "apply-for-something",
       },
     };
     const previewKeys: KeyPath[] = [];
@@ -20,15 +23,18 @@ describe("extractSessionPreviewData", () => {
   test("keys must be present in the passport", () => {
     const invalidSession: Session = {
       id: "abc",
-      flowId: "abc",
       data: {
-        id: "abc",
+        id: "flow-abc",
         passport: {
           data: {
             key1: "a",
           },
         },
         breadcrumbs: {},
+      },
+      flow: {
+        id: "flow-abc",
+        slug: "apply-for-something",
       },
     };
     const previewKeys: KeyPath[] = [["key1"], ["key2", "notFoundKey"]];
@@ -39,9 +45,8 @@ describe("extractSessionPreviewData", () => {
   test("a simple set of session preview keys are extracted from the session", () => {
     const session: Session = {
       id: "abc",
-      flowId: "abc",
       data: {
-        id: "abc",
+        id: "flow-abc",
         passport: {
           data: {
             a: 1,
@@ -50,6 +55,10 @@ describe("extractSessionPreviewData", () => {
           },
         },
         breadcrumbs: {},
+      },
+      flow: {
+        id: "flow-abc",
+        slug: "apply-for-something",
       },
     };
     const previewKeys: KeyPath[] = [["a"], ["b"], ["c"]];
@@ -64,9 +73,8 @@ describe("extractSessionPreviewData", () => {
   test("a set of compound keys are extracted from the session", () => {
     const session: Session = {
       id: "abc",
-      flowId: "abc",
       data: {
-        id: "abc",
+        id: "flow-abc",
         passport: {
           data: {
             "a.b": 1,
@@ -76,6 +84,10 @@ describe("extractSessionPreviewData", () => {
         },
         breadcrumbs: {},
       },
+      flow: {
+        id: "flow-abc",
+        slug: "apply-for-something",
+      },
     };
     const previewKeys: KeyPath[] = [["a.b"], ["c.d"], ["c.d.e"]];
     const sessionPreviewData = extractSessionPreviewData(session, previewKeys);
@@ -84,9 +96,8 @@ describe("extractSessionPreviewData", () => {
   test("a set of nested and compound keys are extracted from the session", () => {
     const session: Session = {
       id: "abc",
-      flowId: "abc",
       data: {
-        id: "abc",
+        id: "flow-abc",
         passport: {
           data: {
             a: {
@@ -100,6 +111,10 @@ describe("extractSessionPreviewData", () => {
           },
         },
         breadcrumbs: {},
+      },
+      flow: {
+        id: "flow-abc",
+        slug: "apply-for-something",
       },
     };
     const previewKeys: KeyPath[] = [

--- a/src/requests/payment-request.ts
+++ b/src/requests/payment-request.ts
@@ -166,7 +166,7 @@ async function getPaymentAmount(
 ): Promise<number | undefined> {
   const flow: FlowGraph | null = await getLatestFlowGraph(
     client,
-    session.flowId,
+    session.flow.id,
   );
   if (!flow) {
     throw new Error("flow not found");

--- a/src/requests/session.ts
+++ b/src/requests/session.ts
@@ -73,9 +73,12 @@ export async function getSessionById(
       gql`
         query GetSessionById($id: uuid!) {
           lowcal_sessions_by_pk(id: $id) {
-            data
-            flowId: flow_id
             id
+            data
+            flow {
+              id
+              slug
+            }
           }
         }
       `,

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -11,13 +11,16 @@ export type SessionData = {
   passport: Passport;
   breadcrumbs: Breadcrumbs;
   govUkPayment?: GovUKPayment;
-  id: string;
+  id: string; // flowId
 };
 
 export type Session = {
-  data: SessionData;
   id: string;
-  flowId: string;
+  data: SessionData;
+  flow: {
+    id: string;
+    slug: string;
+  };
 };
 
 export type DetailedSession = Session & {


### PR DESCRIPTION
We call `$api.session.find()` when creating the export zip - and we want access to the flow slug for its' filename.