### PR TITLE
fix: update `DetailedSession` type

### DIFF
--- a/src/requests/session.ts
+++ b/src/requests/session.ts
@@ -98,10 +98,13 @@ export async function getDetailedSessionById(
       query GetSessionDetails($id: uuid!) {
         lowcal_sessions_by_pk(id: $id) {
           id
-          flowId: flow_id
           lockedAt: locked_at
           submittedAt: submitted_at
           data
+          flow {
+            id
+            slug
+          }
         }
       }
     `,


### PR DESCRIPTION
Followup from #328  - `DetailedSession` type is based on `Session` but was still fetching an outdated shape.  

This fixes my `createPaymentRequest` error popping up over here :heavy_check_mark:  https://github.com/theopensystemslab/planx-new/pull/2893 