### PR TITLE
fix: Make `reference_code` mandatory

### DIFF
--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -25,7 +25,7 @@ interface CreateTeam {
   homepage: string;
   submissionEmail?: string;
   boundary?: GeoJsonObject;
-  referenceCode?: string;
+  referenceCode: string;
 }
 
 export class TeamClient {
@@ -122,8 +122,8 @@ export async function createTeam(
       homepage,
     },
     notifyPersonalisation: defaultNotifyPersonalisation,
+    referenceCode,
     ...(boundary && { boundary }),
-    ...(referenceCode && { referenceCode }),
   };
   const response: { insert_teams_one: { id: number } } = await client.request(
     gql`
@@ -134,7 +134,7 @@ export async function createTeam(
         $submissionEmail: String
         $notifyPersonalisation: jsonb!
         $boundary: jsonb
-        $referenceCode: String
+        $referenceCode: String!
       ) {
         insert_teams_one(
           object: {
@@ -143,9 +143,9 @@ export async function createTeam(
             settings: $settings
             submission_email: $submissionEmail
             notify_personalisation: $notifyPersonalisation
+            reference_code: $referenceCode
             # Fall back to default values for optional values
             ${boundary ? "boundary: $boundary" : ""}
-            ${referenceCode ? "reference_code: $referenceCode" : ""}
             # Create empty records for theme and integrations - these can get populated later
             theme: { data: {} }
             integrations: { data: {} }


### PR DESCRIPTION
This field is actually required in order to generate a valid DigitalPlanning payload. Please see https://github.com/theopensystemslab/planx-new/pull/2918 for context.