### PR TITLE
fix: adjust `preApp.summary` passport mapping for ODP Schema

### DIFF
--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -541,7 +541,7 @@ export class DigitalPlanning {
       reference: this.passport.data?.["application.preAppAdvice.reference"],
       date: this.passport.data?.["application.preApp.date"],
       officer: this.passport.data?.["application.preAppAdvice.officerName"],
-      summary: this.passport.data?.["application.preApp.summary"],
+      summary: this.passport.data?.["application.preApp.summary"]?.[0],
     } as Payload["data"]["application"]["preApp"];
   }
 


### PR DESCRIPTION
Fixes validation error for https://planx.airbrake.io/projects/329753/groups/3768516899831389867

See original passport here: https://api.editor.planx.uk/admin/session/33181543-e0cd-4bb1-9a91-6e97a88834fc/summary