### PR TITLE
chore: update @opensystemslab/map package and planning.data source links

### DIFF
--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -470,7 +470,7 @@ export class DigitalPlanning {
                             ? { text: "Ordnance Survey MasterMap Highways" }
                             : {
                                 text: "Planning Data",
-                                url: `https://planning.data.gov.uk/entity/${entity.entity}`,
+                                url: `https://www.planning.data.gov.uk/entity/${entity.entity}`,
                               },
                       },
                   ) || [],

--- a/src/templates/html/application/ApplicationHTML.tsx
+++ b/src/templates/html/application/ApplicationHTML.tsx
@@ -254,7 +254,7 @@ export function ApplicationHTML(props: {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <script src="https://cdn.jsdelivr.net/npm/@opensystemslab/map@0.8.0"></script>
+        <script src="https://cdn.jsdelivr.net/npm/@opensystemslab/map@0.8.1"></script>
         <title>{typeof documentTitle === "string" && documentTitle}</title>
         <link
           rel="stylesheet"

--- a/src/templates/html/map/MapHTML.tsx
+++ b/src/templates/html/map/MapHTML.tsx
@@ -13,7 +13,7 @@ export function MapHTML(props: {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <script src="https://cdn.jsdelivr.net/npm/@opensystemslab/map@0.8.0"></script>
+        <script src="https://cdn.jsdelivr.net/npm/@opensystemslab/map@0.8.1"></script>
         <title>PlanX Submission Boundary</title>
         <link
           rel="stylesheet"


### PR DESCRIPTION
Two small maintenance tasks related to submissions & doc templates:
- BOPS flagged that `planning.data.gov.uk` JSON entity links are now redirecting to `www.planning.data.gov.uk` so let's set that directly https://opendigitalplanning.slack.com/archives/C0182MVK4AW/p1712570743064369
- Document templates should use latest `@opensystemslab/map` release for accessibility improvements