### PR TITLE
feat: `formatGovPayMetadata()` helper

### DIFF
--- a/src/types/gov-uk-payment.ts
+++ b/src/types/gov-uk-payment.ts
@@ -44,3 +44,31 @@ export interface GovUKPayment {
 }
 
 export const GOV_PAY_PASSPORT_KEY = "application.fee.reference.govPay" as const;
+
+export type GovPayMetadataValue = string | boolean | number;
+
+// https://docs.payments.service.gov.uk/making_payments/#creating-a-payment
+export interface GovUKCreatePaymentPayload {
+  amount: number;
+  reference: string;
+  description: string;
+  return_url: string;
+  email?: string;
+  prefilled_cardholder_details?: {
+    cardholder_name?: string;
+    billing_address?: {
+      line1: string;
+      line2: string;
+      postcode: string;
+      city: string;
+      country: string;
+    };
+  };
+  language?: string;
+  metadata?: Record<string, GovPayMetadataValue>;
+}
+
+export interface GovPayMetadata {
+  key: string;
+  value: GovPayMetadataValue;
+}

--- a/src/utils/govPayMetadata.test.ts
+++ b/src/utils/govPayMetadata.test.ts
@@ -1,0 +1,119 @@
+import type { GovPayMetadata, Passport } from "../types";
+import { formatGovPayMetadata } from "./govPayMetadata";
+
+const mockMetadata: GovPayMetadata[] = [
+  { key: "firstKey", value: "firstValue" },
+  { key: "secondKey", value: "secondValue" },
+  { key: "key_string", value: "@string" },
+  { key: "key_stringGreaterThan100Chars", value: "@stringGreaterThan100Chars" },
+  { key: "key_stringArray", value: "@stringArray" },
+  {
+    key: "key_stringArrayGreaterThan100Chars",
+    value: "@stringArrayGreaterThan100Chars",
+  },
+  { key: "key_number", value: "@number" },
+  { key: "key_object", value: "@object" },
+  { key: "key_boolean", value: "@boolean" },
+  {
+    key: "key_someValueNotSetInPassport",
+    value: "@someValueNotSetInPassportolean",
+  },
+];
+
+const mockPassport: Passport = {
+  data: {
+    string: "agent",
+    stringGreaterThan100Chars:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus volutpat ex a tempor facilisis. Nullam eget mi velit.",
+    stringArray: ["new.building", "new.solarPanel"],
+    stringArrayGreaterThan100Chars: [
+      "Lorem ipsum dolor sit amet",
+      "consectetur adipiscing eli",
+      "Phasellus volutpat ex a tempor facilisis",
+      "Nullam eget mi velit",
+    ],
+    number: 123,
+    object: { someGeoJSON: { abc: 123 } },
+    boolean: true,
+  },
+};
+
+describe("transforming the payload to the correct format for GovPay", () => {
+  it("handles variables set in the Editor", () => {
+    const result = formatGovPayMetadata(mockMetadata, mockPassport);
+    expect(result).toMatchObject({
+      firstKey: "firstValue",
+      secondKey: "secondValue",
+    });
+  });
+
+  it("handles variables set in the Passport", () => {
+    const result = formatGovPayMetadata(mockMetadata, mockPassport);
+    expect(result).toMatchObject({
+      key_string: "agent",
+      key_boolean: true,
+    });
+  });
+});
+
+describe("validating data", () => {
+  const formatted = formatGovPayMetadata(mockMetadata, mockPassport);
+
+  const get = (testKey: string) => [
+    mockPassport.data[testKey], // Expected
+    formatted[`key_${testKey}`], // Result
+  ];
+
+  it("accepts strings", () => {
+    const [expected, result] = get("string");
+    // Value parsed as-is, no changes made
+    expect(result).toBe(expected);
+  });
+
+  it("accepts numbers", () => {
+    const [expected, result] = get("number");
+    // Value parsed as-is, no changes made
+    expect(result).toBe(expected);
+  });
+
+  it("accepts booleans", () => {
+    const [expected, result] = get("boolean");
+    // Value parsed as-is, no changes made
+    expect(result).toBe(expected);
+  });
+
+  it("converts string arrays to string", () => {
+    const [_, result] = get("stringArray");
+    const expected = "new.building, new.solarPanel";
+    // Array of strings joined to single string
+    expect(result).toBe(expected);
+  });
+
+  it("returns an error for undefined values", () => {
+    const [_, result] = get("someValueNotSetInPassport");
+    // Error passed to GovPay API as string, payment allows to proceed
+    expect(result).toMatch(
+      /Error: Invalid metadata value for "key_someValueNotSetInPassport" set in PlanX/,
+    );
+  });
+
+  it("returns an error for objects", () => {
+    const [_, result] = get("object");
+    // Error passed to GovPay API as string, payment allows to proceed
+    expect(result).toMatch(
+      /Error: Invalid metadata value for "key_object" set in PlanX/,
+    );
+  });
+
+  it("truncates long strings", () => {
+    const [_, result] = get("stringGreaterThan100Chars");
+    // Truncated to 100 characters to meet GovPay API requirements
+    expect(result).toHaveLength(100);
+  });
+
+  it("truncates long strings from arrays", () => {
+    const [_, result] = get("stringArrayGreaterThan100Chars");
+    // Truncated to 100 characters to meet GovPay API requirements
+    expect(result).toHaveLength(100);
+  });
+});

--- a/src/utils/govPayMetadata.test.ts
+++ b/src/utils/govPayMetadata.test.ts
@@ -109,11 +109,15 @@ describe("validating data", () => {
     const [_, result] = get("stringGreaterThan100Chars");
     // Truncated to 100 characters to meet GovPay API requirements
     expect(result).toHaveLength(100);
+    // String ends in ellipsis (...)
+    expect(result).toMatch(/.*\.\.\.$/);
   });
 
   it("truncates long strings from arrays", () => {
     const [_, result] = get("stringArrayGreaterThan100Chars");
     // Truncated to 100 characters to meet GovPay API requirements
     expect(result).toHaveLength(100);
+    // String ends in ellipsis (...)
+    expect(result).toMatch(/.*\.\.\.$/);
   });
 });

--- a/src/utils/govPayMetadata.ts
+++ b/src/utils/govPayMetadata.ts
@@ -77,8 +77,8 @@ const validateMetadata = (
  *
  * @description
  * Metadata can take one of two forms -
- *  - Static values (e.g. vat_code: "abc123")
- *  - Dynamic values (e.g. property_type: "@project.propertyType")
+ *  - Static values (e.g. { vat_code: "abc123" })
+ *  - Dynamic values (e.g. { property_type: "@project.propertyType" })
  */
 export const formatGovPayMetadata = (
   metadata: GovPayMetadata[],

--- a/src/utils/govPayMetadata.ts
+++ b/src/utils/govPayMetadata.ts
@@ -1,0 +1,91 @@
+import { Passport } from "../models";
+import {
+  GovPayMetadata,
+  GovPayMetadataValue,
+  GovUKCreatePaymentPayload,
+  Passport as IPassport,
+  Value,
+} from "../types";
+
+type FormattedMetadata = NonNullable<GovUKCreatePaymentPayload["metadata"]>;
+
+const isPassportValue = (value: GovPayMetadataValue) =>
+  typeof value === "string" && value.startsWith("@");
+
+/**
+ * Convert GovPayMetadata set in Editor to format accepted by GovPay API
+ * Read dynamic data variables from passport and inject into output
+ */
+const parseMetadata = (
+  metadata: GovPayMetadata[],
+  passport: Passport,
+): FormattedMetadata => {
+  let entries: [string, GovPayMetadataValue][] = [];
+
+  entries = metadata.map(({ key, value }) => {
+    if (!isPassportValue(value)) return [key, value];
+
+    // Remove "@" prefix
+    const passportKey = (value as string).substring(1);
+    const passportValue = passport.any<Value>([passportKey]);
+
+    // Validate and format
+    const validatedValue = validateMetadata(key, passportValue);
+    return [key, validatedValue];
+  });
+
+  const parsedMetadata = Object.fromEntries(entries);
+  return parsedMetadata;
+};
+
+/**
+ * Validate that GovPayMetadata formatting rules are adhered to
+ * Initial validation is done in-Editor, this is intended to catch issues
+ * with dynamic passport variables
+ */
+const validateMetadata = (
+  key: string,
+  value: Value | undefined,
+): GovPayMetadataValue => {
+  let validated: GovPayMetadataValue | null = null;
+
+  switch (typeof value) {
+    case "string":
+    case "number":
+    case "boolean":
+      validated = value;
+      break;
+    case "object":
+      validated = Array.isArray(value)
+        ? value.join(", ")
+        : `Error: Invalid metadata value for "${key}" set in PlanX`;
+      break;
+    default:
+      validated = `Error: Invalid metadata value for "${key}" set in PlanX`;
+      break;
+  }
+
+  // Truncate to max 100 characters
+  // TODO: Should we truncate or throw error here?
+  if (typeof validated === "string") validated = validated.substring(0, 100);
+
+  return validated;
+};
+
+/**
+ * Format and validate metadata set by Editors in Pay component for consumption by GovPay
+ *
+ * @description
+ * Metadata can take one of two forms -
+ *  - Static values (e.g. vat_code: "abc123")
+ *  - Dynamic values (e.g. property_type: "@project.propertyType")
+ */
+export const formatGovPayMetadata = (
+  metadata: GovPayMetadata[],
+  userPassport: IPassport,
+): FormattedMetadata => {
+  const passport = new Passport(userPassport);
+  const parsedAndValidated = parseMetadata(metadata, passport);
+
+  return parsedAndValidated;
+};

--- a/src/utils/govPayMetadata.ts
+++ b/src/utils/govPayMetadata.ts
@@ -66,8 +66,9 @@ const validateMetadata = (
   }
 
   // Truncate to max 100 characters
-  // TODO: Should we truncate or throw error here?
-  if (typeof validated === "string") validated = validated.substring(0, 100);
+  if (typeof validated === "string" && validated.length >= 97) {
+    validated = validated.substring(0, 97) + "...";
+  }
 
   return validated;
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from "./encryption";
+export * from "./govPayMetadata";


### PR DESCRIPTION
## What does this PR do?
 - Adds a `formatGovPayMetadata()` helper function with two responsibilities - 
   - Format "Editor" data shape used in Edtior modal and saved in `flows` and `payment_request` tables (`Record<string, string | boolean | number>[]`) to data shape required by GovPay API (`Record<string, string>`)
   - Validate that any dynamic variables (taken from Passport) ahere to the validation rules[ outlined by GovPay here](https://docs.payments.service.gov.uk/reporting/#add-more-information-to-a-payment-39-custom-metadata-39-or-39-reporting-columns-39)
 - Moves shared types to `planx-core`

## Motivation
Currently, we have a simpler helper function (`formatMetadata()`) duplicated in Editor and API projects - it's a one-liner that just transforms from shape to shape. 

As we now need the additional logic to both read from the passport, and validate, it makes sense to write and test this once.

Implemented in https://github.com/theopensystemslab/planx-new/pull/3015