### PR TITLE
chore: create and export type `DigitalPlanningSchemaApplicationTypes`

### DIFF
--- a/src/types/digitalPlanningSchema.ts
+++ b/src/types/digitalPlanningSchema.ts
@@ -1,0 +1,3 @@
+import { ApplicationType } from "../export/digitalPlanning/schema/types";
+
+export type DigitalPlanningSchemaApplicationTypes = ApplicationType["value"];


### PR DESCRIPTION
When we generate types from our ODP Schema JSON spec, those types aren't actually exported from planx-core. 

They're pretty huge and noisy and I'm not sure we need to export _all_ of them just yet, but we do want to access some of them (or variations of the original auto-generated types) within `planx-new` - for example to check if the current session's application type falls within our supported list or not to determine which payload to try generating. 