### PR TITLE
fix: account for manually answered planning constraints in ODP Schema generation

### DIFF
--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -496,58 +496,88 @@ export class DigitalPlanning {
 
   private getPlanningConstraints(): Payload["data"]["property"]["planning"] {
     const teamSlug: string = this.metadata.flow.team.slug;
-    const constraints = this.passport.data
-      ?._constraints as unknown as EnhancedGISResponse[];
     const designations: PlanningDesignation[] = [];
 
-    constraints?.forEach((response: EnhancedGISResponse) => {
-      response.constraints &&
-        Object.entries(response.constraints)
-          .filter(([key, _constraint]) => !key.split(".").includes(teamSlug))
-          .map(([key, constraint]) => {
-            if (constraint.value) {
-              // Intersecting constraints
-              designations.push({
-                value: key,
-                description: this.findDescriptionFromValueUnionType(
-                  "PlanningDesignation",
-                  key,
-                ),
-                intersects: constraint.value,
-                entities:
-                  constraint.data?.map(
-                    (entity) =>
-                      Boolean(entity) && {
-                        name: entity.name,
-                        description: entity.description,
-                        source:
-                          key === "road.classified"
-                            ? { text: "Ordnance Survey MasterMap Highways" }
-                            : {
-                                text: "Planning Data",
-                                url: `https://www.planning.data.gov.uk/entity/${entity.entity}`,
-                              },
-                      },
-                  ) || [],
-              } as PlanningDesignation);
-            } else {
-              // Non-intersecting constraints
-              designations.push({
-                value: key,
-                description: this.findDescriptionFromValueUnionType(
-                  "PlanningDesignation",
-                  key,
-                ),
-                intersects: constraint.value,
-              } as PlanningDesignation);
-            }
-          });
-    });
+    // Passport will have `_constraints` if successfully fetched from Planning Data
+    const constraints = this.passport.data
+      ?._constraints as unknown as EnhancedGISResponse[];
 
-    return {
-      sources: constraints?.map((constraint) => constraint.planxRequest) || [],
-      designations: designations,
-    };
+    // Passport will not have `_constraints`, and only `property.constraints.planning` if manually answered
+    const manualConstraints = this.passport.data?.[
+      "property.constraints.planning"
+    ] as string[];
+
+    if (constraints) {
+      constraints?.forEach((response: EnhancedGISResponse) => {
+        response.constraints &&
+          Object.entries(response.constraints)
+            .filter(([key, _constraint]) => !key.split(".").includes(teamSlug))
+            .map(([key, constraint]) => {
+              if (constraint.value) {
+                // Intersecting constraints
+                designations.push({
+                  value: key,
+                  description: this.findDescriptionFromValueUnionType(
+                    "PlanningDesignation",
+                    key,
+                  ),
+                  intersects: constraint.value,
+                  entities:
+                    constraint.data?.map(
+                      (entity) =>
+                        Boolean(entity) && {
+                          name: entity.name,
+                          description: entity.description,
+                          source:
+                            key === "road.classified"
+                              ? { text: "Ordnance Survey MasterMap Highways" }
+                              : {
+                                  text: "Planning Data",
+                                  url: `https://www.planning.data.gov.uk/entity/${entity.entity}`,
+                                },
+                        },
+                    ) || [],
+                } as PlanningDesignation);
+              } else {
+                // Non-intersecting constraints
+                designations.push({
+                  value: key,
+                  description: this.findDescriptionFromValueUnionType(
+                    "PlanningDesignation",
+                    key,
+                  ),
+                  intersects: constraint.value,
+                } as PlanningDesignation);
+              }
+            });
+      });
+
+      return {
+        sources:
+          constraints?.map((constraint) => constraint.planxRequest) || [],
+        designations: designations,
+      };
+    } else if (!constraints && manualConstraints) {
+      manualConstraints
+        .filter((key) => !key.split(".").includes(teamSlug))
+        .map((key) => {
+          designations.push({
+            value: key,
+            description: this.findDescriptionFromValueUnionType(
+              "PlanningDesignation",
+              key,
+            ),
+            intersects: true,
+          } as PlanningDesignation);
+        });
+
+      return {
+        sources: ["Answered by user"],
+        designations: designations,
+      };
+    } else {
+      return undefined;
+    }
   }
 
   private getApplicationType(): Payload["data"]["application"]["type"] {


### PR DESCRIPTION
See thread here (this has only occured on test env, not production): https://opendigitalplanning.slack.com/archives/C0241GWFG4B/p1715963778547149

Previously our passport mappings only checked for `_constraints` key which is populated based on Planning Data fetch.

Now this adds an extra fallback check to map from `property.constraints.planning` in cases of manual user answers (eg see this session's passport: https://api.editor.planx.dev/admin/session/74068ec3-2e9c-408a-ac6f-7832d1eb011f/summary)