### PR TITLE
fix: ensure owners `noticeGiven` is correctly cast to boolean

### DIFF
--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -213,10 +213,11 @@ export class DigitalPlanning {
           ...(!this.passport.data?.[
             "property.ownership.ownerOne.noticeDate"
           ] && {
-            noticeGiven:
+            noticeGiven: this.stringToBool(
               this.passport.data?.[
                 "property.ownership.ownerOne.noticeGiven"
               ]?.[0],
+            ),
             ...(this.passport.data?.[
               "property.ownership.ownerOne.noticeGiven"
             ]?.[0] === "false" && {
@@ -237,10 +238,11 @@ export class DigitalPlanning {
           ...(!this.passport.data?.[
             "property.ownership.ownerTwo.noticeDate"
           ] && {
-            noticeGiven:
+            noticeGiven: this.stringToBool(
               this.passport.data?.[
                 "property.ownership.ownerTwo.noticeGiven"
               ]?.[0],
+            ),
             ...(this.passport.data?.[
               "property.ownership.ownerTwo.noticeGiven"
             ]?.[0] === "false" && {


### PR DESCRIPTION
This staging LDC failed because we have `data.applicant.ownership.owners[0].noticeGiven` = `"true"`, when it should be a proper boolean!

https://api.editor.planx.dev/admin/session/e42c9ebc-039f-4609-a7df-3c98f23e7d53/digital-planning-application?skipValidation=true

