### PR TITLE
fix: update started & completed date mappings for ODP Schema

### DIFF
--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -762,8 +762,8 @@ export class DigitalPlanning {
         (this.passport.data?.["proposal.description"] as string) ||
         "Not provided",
       date: {
-        start: this.passport.data?.["proposal.start.date"] as string,
-        completion: this.passport.data?.["proposal.completion.date"] as string,
+        start: this.passport.data?.["proposal.started.date"] as string,
+        completion: this.passport.data?.["proposal.completed.date"] as string,
       },
       ...(this.passport.data?.["property.boundary.site"] && {
         boundary: this.getProposedBoundary(),

--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -762,8 +762,10 @@ export class DigitalPlanning {
         (this.passport.data?.["proposal.description"] as string) ||
         "Not provided",
       date: {
-        start: this.passport.data?.["proposal.started.date"] as string,
-        completion: this.passport.data?.["proposal.completed.date"] as string,
+        start: (this.passport.data?.["proposal.started.date"] ||
+          this.passport.data?.["proposal.start.date"]) as string,
+        completion: (this.passport.data?.["proposal.completed.date"] ||
+          this.passport.data?.["proposal.completion.date"]) as string,
       },
       ...(this.passport.data?.["property.boundary.site"] && {
         boundary: this.getProposedBoundary(),


### PR DESCRIPTION
Based on feedback from August: 
> Came across some major inconsistency around start.date / started.date / completed.date / completion.date / finish.date etc.
>
> I changed that all to (for both intended and actual dates as they're mutually exclusive):
> - proposal.completed.date
> - proposal.started.date
>
> In the schema and content wherever I saw it.

Using our previous values as fallbacks still while we wait for service publishing to catch up!