### PR TITLE
feat: Adding "Name" to the "Session" type for Email Templates 

### DIFF
--- a/src/export/oneApp/mocks/session.ts
+++ b/src/export/oneApp/mocks/session.ts
@@ -13,5 +13,6 @@ export const mockSession: Session = {
   flow: {
     id: "flow123",
     slug: "apply-for-something",
+    name: "Apply for Something",
   },
 };

--- a/src/requests/payment-request.test.ts
+++ b/src/requests/payment-request.test.ts
@@ -13,6 +13,7 @@ describe("extractSessionPreviewData", () => {
       flow: {
         id: "flow-abc",
         slug: "apply-for-something",
+        name: "Apply for Something",
       },
     };
     const previewKeys: KeyPath[] = [];
@@ -35,6 +36,7 @@ describe("extractSessionPreviewData", () => {
       flow: {
         id: "flow-abc",
         slug: "apply-for-something",
+        name: "Apply for Something",
       },
     };
     const previewKeys: KeyPath[] = [["key1"], ["key2", "notFoundKey"]];
@@ -59,6 +61,7 @@ describe("extractSessionPreviewData", () => {
       flow: {
         id: "flow-abc",
         slug: "apply-for-something",
+        name: "Apply for Something",
       },
     };
     const previewKeys: KeyPath[] = [["a"], ["b"], ["c"]];
@@ -87,6 +90,7 @@ describe("extractSessionPreviewData", () => {
       flow: {
         id: "flow-abc",
         slug: "apply-for-something",
+        name: "Apply for Something",
       },
     };
     const previewKeys: KeyPath[] = [["a.b"], ["c.d"], ["c.d.e"]];
@@ -115,6 +119,7 @@ describe("extractSessionPreviewData", () => {
       flow: {
         id: "flow-abc",
         slug: "apply-for-something",
+        name: "Apply for Something",
       },
     };
     const previewKeys: KeyPath[] = [

--- a/src/requests/session.ts
+++ b/src/requests/session.ts
@@ -78,6 +78,7 @@ export async function getSessionById(
             flow {
               id
               slug
+              name
             }
           }
         }
@@ -104,6 +105,7 @@ export async function getDetailedSessionById(
           flow {
             id
             slug
+            name
           }
         }
       }
@@ -166,6 +168,7 @@ export async function getSessionMetadata(
             flow {
               id
               slug
+              name
               team {
                 name
                 slug

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -20,6 +20,7 @@ export type Session = {
   flow: {
     id: string;
     slug: string;
+    name: string;
   };
 };
 


### PR DESCRIPTION
# What does this PR do?

``InviteToPayData`` & ``InviteToPayMocks`` from **planx-new** are using the ``Session`` type when building the variables for the email templates. In order to use the new ``name`` column as the ``sessionName`` I need to update this ``Session`` type.