### PR TITLE
chore: update schema passport mappings so that Prior Approvals set GLA requirements

### DIFF
--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -803,11 +803,9 @@ export class DigitalPlanning {
       );
     }
 
-    // Prior Approvals will use London Data Hub in future, but don't yet https://editor.planx.uk/opensystemslab/prior-approval-more-information
-    // Listed Building Consent will never use London Data Hub
+    // Listed Building Consent apps will never use London Data Hub
     if (
       this.passport.data?.["property.region"]?.[0] === "London" &&
-      !this.passport.data?.["application.type"]?.[0]?.startsWith("pa") &&
       this.passport.data?.["application.type"]?.[0] !== "listed"
     ) {
       PARKING_TYPES.forEach((type) => {


### PR DESCRIPTION
Prior Approvals now go through the `london-data-hub` flow too