### PR TITLE
fix: Don't allow undefined file URLs

### DIFF
--- a/src/models/passport/passport.ts
+++ b/src/models/passport/passport.ts
@@ -37,9 +37,12 @@ export class Passport {
       QuestionWithFiles[],
     ]): File[] => questionWithFiles.map(({ url }) => ({ key, url }));
 
+    const isSuccess = (file: File) => Boolean(file.url);
+
     const fileDetails = Object.entries(this.data)
       .filter(isFileUploadQuestion)
-      .flatMap(buildFileDetails);
+      .flatMap(buildFileDetails)
+      .filter(isSuccess);
 
     return fileDetails;
   }


### PR DESCRIPTION
## What's the problem?
 - A recent submission fails to generate a `.zip` file as some of the URLs returned by `Passport().getFileURLs()` return as `undefined`
 - This means that the submission cannot be generated
 - Source: https://opendigitalplanning.slack.com/archives/C0241GWFG4B/p1719915590451399 (ODP Slack)

## Why is this happening?
This is happening as some file upload breadcrumbs return with a status of `"error"`. See sanitised example below of fragment of invalid passport

```json
{
  "data": {
    "nodeIdOfFileUploadComponent": [
      {
        "url": "https://api.editor.planx.uk/someUrl/test.pdf",
        "filename": "test.pdf",
        "cachedSlot": {
          "id": "yGcR1uDwJ0zxPJ-ftY4GQ",
          "url": "https://api.editor.planx.uk/someUrl/test.pdf",
          "file": {
            "path": "test.pdf",
            "size": 3431233,
            "type": "application/pdf"
          },
          "status": "success",
          "progress": 1
        }
      },
      {
        "filename": "test2.pdf",
        "cachedSlot": {
          "id": "32fdfdsf555gss",
          "file": {
            "path": "test2.pdf",,
            "size": 34792,
            "type": "application/pdf"
          },
          // This is the problem
          // "url" property also missing as a result
          "status": "error",
          "progress": 1
        }
      }
      ...
    ]
    ...
  }
}
```

## What's the solution?
- Quick fix - filter these out when returning a response (this PR)
- Proper fix - check component logic to ensure that any files without a status of `"success"` are not added to breadcrumbs (upcoming planx-new PR)