### PR TITLE
feat: get and export original enum values from json schema spec 

### DIFF
--- a/src/utils/digitalPlanningSchema.test.ts
+++ b/src/utils/digitalPlanningSchema.test.ts
@@ -1,19 +1,38 @@
-import { getValidSchemaValues } from "./digitalPlanningSchema";
+import {
+  getValidSchemaDictionary,
+  getValidSchemaValues,
+} from "./digitalPlanningSchema";
 
 describe("get valid schema values", () => {
   it("should return a list of values for a valid enum definition", () => {
     const values = getValidSchemaValues("FileType");
 
-    // it only returns the values, not description
+    // Spot check: it only returns the values, not description
     expect(values).toContain("accessRoadsRightsOfWayDetails");
-    expect(values?.length).toBeGreaterThan(30); // just a rough check!
     expect(values).not.toContain(
       "Details of impact on access, roads, and rights of way",
     );
+    expect(values?.length).toBeGreaterThan(30); // just a rough check!
   });
 
   it("should return undefined for an invalid enum definition", () => {
     const values = getValidSchemaValues("ZooAnimals");
     expect(values).toBeUndefined();
+  });
+});
+
+describe("get valid schema values and descriptions", () => {
+  it("should return a dictionary for a valid enum definition", () => {
+    const dict = getValidSchemaDictionary("FileType");
+
+    // Spot check a specific key/value
+    expect(dict).toHaveProperty("heritageStatement");
+    expect(dict?.["heritageStatement"]).toEqual("Heritage Statement");
+    expect(dict && Object.keys(dict).length).toBeGreaterThan(30); // another rough check!
+  });
+
+  it("should return undefined for an invalid enum definition", () => {
+    const dict = getValidSchemaValues("ZooAnimals");
+    expect(dict).toBeUndefined();
   });
 });

--- a/src/utils/digitalPlanningSchema.test.ts
+++ b/src/utils/digitalPlanningSchema.test.ts
@@ -1,0 +1,19 @@
+import { getValidSchemaValues } from "./digitalPlanningSchema";
+
+describe("get valid schema values", () => {
+  it("should return a list of values for a valid enum definition", () => {
+    const values = getValidSchemaValues("FileType");
+
+    // it only returns the values, not description
+    expect(values).toContain("accessRoadsRightsOfWayDetails");
+    expect(values?.length).toBeGreaterThan(30); // just a rough check!
+    expect(values).not.toContain(
+      "Details of impact on access, roads, and rights of way",
+    );
+  });
+
+  it("should return undefined for an invalid enum definition", () => {
+    const values = getValidSchemaValues("ZooAnimals");
+    expect(values).toBeUndefined();
+  });
+});

--- a/src/utils/digitalPlanningSchema.ts
+++ b/src/utils/digitalPlanningSchema.ts
@@ -8,7 +8,7 @@ import jsonSchema from "../export/digitalPlanning/schema/schema.json";
 export function getValidSchemaValues(definition: string): string[] | undefined {
   try {
     return jsonSchema["definitions"][definition]["anyOf"].map(
-      (types: Record<string, string>) => types.properties["value"]?.const,
+      (types: Record<string, string>) => types.properties["value"].const,
     );
   } catch (error) {
     console.log(
@@ -27,7 +27,14 @@ export function getValidSchemaDictionary(
   definition: string,
 ): Record<string, string> | undefined {
   try {
-    // TODO
+    const dict: Record<string, string> = {};
+    jsonSchema["definitions"][definition]["anyOf"].map(
+      (types: Record<string, string>) => {
+        dict[types.properties["value"].const] =
+          types.properties["description"].const;
+      },
+    );
+    return dict;
   } catch (error) {
     console.log(
       `Cannot find enum definition '${definition}' in json schema: ${error}`,

--- a/src/utils/digitalPlanningSchema.ts
+++ b/src/utils/digitalPlanningSchema.ts
@@ -1,0 +1,37 @@
+import jsonSchema from "../export/digitalPlanning/schema/schema.json";
+
+/**
+ * For a given 'anyOf' enum definition in the JSON Schema (with properties `value` & `description`), return its valid `values`
+ * @param definition eg 'FileType'
+ * @returns list of values
+ */
+export function getValidSchemaValues(definition: string): string[] | undefined {
+  try {
+    return jsonSchema["definitions"][definition]["anyOf"].map(
+      (types: Record<string, string>) => types.properties["value"]?.const,
+    );
+  } catch (error) {
+    console.log(
+      `Cannot find enum definition '${definition}' in json schema: ${error}`,
+    );
+    return undefined;
+  }
+}
+
+/**
+ * For a given 'anyOf' enum definition in the JSON Schema (with properties `value` & `description`), return a dictionary of its valid options
+ * @param definition eg 'FileType'
+ * @returns dictionary { [value]: description }
+ */
+export function getValidSchemaDictionary(
+  definition: string,
+): Record<string, string> | undefined {
+  try {
+    // TODO
+  } catch (error) {
+    console.log(
+      `Cannot find enum definition '${definition}' in json schema: ${error}`,
+    );
+    return undefined;
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
+export * from "./digitalPlanningSchema";
 export * from "./encryption";
 export * from "./govPayMetadata";


### PR DESCRIPTION
**Problem:**
- We define "enums" in the Digital Planning Data Schemas repository that are converted into a TypeScript type that then generates the schema.json file
- We import that schema.json file in this repository, and regenerate types based on it, but it's difficult to get back to the plain original dictionary enum variables. 
  - We want to access those enum variables, not the types, to do simple validation checks on publish in the Planx Editor (eg "is every `fn` set by a FileUpload or FileUploadAndLabel component supported in the `FileType` definition of the ODP Schema?")

**Changes:**
- Define and make available a few simple utility methods to parse the `schema.json` file and return either a list of the passport values associated with a definition, or the original value/description dictionary
- Basic tests