### PR TITLE
fix: Remove duplicated `referenceCode` from `CreateTeam` query

### DIFF
--- a/src/export/digitalPlanning/model.test.ts
+++ b/src/export/digitalPlanning/model.test.ts
@@ -26,7 +26,9 @@ const mockMetadataForSession = (
     team: {
       name: teamSlug,
       slug: teamSlug,
-      referenceCode: referenceCode,
+      settings: {
+        referenceCode: referenceCode,
+      },
     },
   },
 });

--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -986,7 +986,7 @@ export class DigitalPlanning {
   private getMetadata(): Payload["metadata"] {
     return {
       id: this.sessionId,
-      organisation: this.metadata.flow.team.referenceCode,
+      organisation: this.metadata.flow.team.settings.referenceCode,
       submittedAt: new Date().toISOString(),
       source: "PlanX",
       service: {

--- a/src/requests/session.ts
+++ b/src/requests/session.ts
@@ -172,7 +172,9 @@ export async function getSessionMetadata(
               team {
                 name
                 slug
-                referenceCode: reference_code
+                settings: team_settings {
+                  referenceCode: reference_code
+                }
               }
             }
           }

--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -96,11 +96,6 @@ export async function createTeam(
   client: GraphQLClient,
   newTeam: NewTeam,
 ): Promise<number> {
-  const input = {
-    ...newTeam,
-    settings: newTeam.settings ?? {},
-    theme: newTeam.theme ?? {},
-  };
   const response: { insert_teams_one: { id: number } } = await client.request(
     gql`
       mutation CreateTeam(
@@ -108,7 +103,6 @@ export async function createTeam(
         $slug: String!
         $domain: String
         $submissionEmail: String
-        $referenceCode: String
         $settings: team_settings_insert_input!
         $theme: team_themes_insert_input!
       ) {
@@ -118,7 +112,6 @@ export async function createTeam(
             slug: $slug
             domain: $domain
             submission_email: $submissionEmail
-            reference_code: $referenceCode
             # Create empty records for associated tables - these can get populated later
             team_settings: { data: $settings }
             theme: { data: $theme }
@@ -129,7 +122,29 @@ export async function createTeam(
         }
       }
     `,
-    input,
+    {
+      ...newTeam,
+      settings: {
+        boundary_url: newTeam?.settings?.boundaryUrl,
+        boundary_bbox: newTeam?.settings?.boundaryBBox,
+        reference_code: newTeam?.settings?.referenceCode,
+        help_email: newTeam?.settings?.helpEmail,
+        help_phone: newTeam?.settings?.helpPhone,
+        help_opening_hours: newTeam?.settings?.helpOpeningHours,
+        email_reply_to_id: newTeam?.settings?.emailReplyToId,
+        homepage: newTeam?.settings?.homepage,
+        external_planning_site_url: newTeam?.settings?.externalPlanningSiteUrl,
+        external_planning_site_name:
+          newTeam?.settings?.externalPlanningSiteName,
+      },
+      theme: {
+        primary_colour: newTeam.theme?.primaryColour,
+        action_colour: newTeam.theme?.actionColour,
+        link_colour: newTeam.theme?.linkColour,
+        logo: newTeam.theme?.logo,
+        favicon: newTeam.theme?.favicon,
+      },
+    },
   );
   return response.insert_teams_one.id;
 }

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -69,7 +69,9 @@ export type SessionMetadata = {
     team: {
       name: string;
       slug: string;
-      referenceCode: string;
+      settings: {
+        referenceCode: string;
+      };
     };
   };
 };


### PR DESCRIPTION
## What does this PR do?
- Follow up to #448 
- Fixes a few things missed in this PR
  - Proper handling of camelCase → snake_case
  - Updated query when building DPA payload