### PR TITLE
Feat: Add MapAndLabel as Enum to Component Type

### DIFF
--- a/src/export/bops/index.ts
+++ b/src/export/bops/index.ts
@@ -73,6 +73,7 @@ function isTypeForBopsPayload(type?: ComponentType) {
     case ComponentType.SetValue:
     case ComponentType.TaskList:
     case ComponentType.List:
+    case ComponentType.MapAndLabel:
       return false;
 
     case ComponentType.AddressInput:

--- a/src/export/bops/index.ts
+++ b/src/export/bops/index.ts
@@ -48,6 +48,8 @@ const bopsDictionary = {
 function isTypeForBopsPayload(type?: ComponentType) {
   if (!type) return false;
 
+  //To-Do Set MapAndLabel to True once we know shape of BOPs data
+
   switch (type) {
     case ComponentType.Calculate:
     case ComponentType.Confirmation:

--- a/src/types/component.ts
+++ b/src/types/component.ts
@@ -16,6 +16,7 @@ export enum ComponentType {
   FileUpload = 140,
   FileUploadAndLabel = 145,
   NumberInput = 150,
+  MapAndLabel = 155,
   Answer = 200, // Response
   Content = 250,
   InternalPortal = 300,


### PR DESCRIPTION
## What does this PR do?

This PR sets up work to introduce a new @planx component called **MapAndLabel**.

Following the steps set out here: https://github.com/theopensystemslab/planx-new/blob/main/editor.planx.uk/docs/adding-a-new-component.md

I have added MapAndLabel as an enum for the ``ComponentType``

I tried to follow current pattern of enums and placed in section alongside `FileUploadAndLabel`