### PR TITLE
feat: Adding domain to the getTeamBySlug query

### DIFF
--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -244,6 +244,7 @@ async function getBySlug(client: GraphQLClient, slug: string) {
           id
           name
           slug
+          domain
           theme {
             primaryColour: primary_colour
             actionColour: action_colour


### PR DESCRIPTION
## What does this PR do?

To enable work being carried out in planx-new: https://github.com/theopensystemslab/planx-new/pull/3483

I want to retrieve the `domain` when fetching a team from the database, so it can be shown to the user in the new Links dialog box