### PR TITLE
chore: Update upsertMember type to generic Role

### DIFF
--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -1,14 +1,14 @@
 import type { GraphQLClient } from "graphql-request";
 import { gql } from "graphql-request";
 
-import { TeamRole } from "../types/roles";
+import { Role } from "../types/roles";
 import { Team, TeamSettings, TeamTheme } from "../types/team";
 import { decrypt } from "../utils/encryption";
 
 interface UpsertMember {
   userId: number;
   teamId: number;
-  role: TeamRole;
+  role: Role;
 }
 
 interface RemoveMember {

--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -1,14 +1,14 @@
 import type { GraphQLClient } from "graphql-request";
 import { gql } from "graphql-request";
 
-import { TeamRole, UserRole } from "../types";
+import { EditorRole } from "../types";
 import { Team, TeamSettings, TeamTheme } from "../types/team";
 import { decrypt } from "../utils/encryption";
 
 interface UpsertMember {
   userId: number;
   teamId: number;
-  role: TeamRole | UserRole;
+  role: EditorRole;
 }
 
 interface RemoveMember {

--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -1,14 +1,14 @@
 import type { GraphQLClient } from "graphql-request";
 import { gql } from "graphql-request";
 
-import { Role } from "../types/roles";
+import { TeamRole, UserRole } from "../types";
 import { Team, TeamSettings, TeamTheme } from "../types/team";
 import { decrypt } from "../utils/encryption";
 
 interface UpsertMember {
   userId: number;
   teamId: number;
-  role: Role;
+  role: TeamRole | UserRole;
 }
 
 interface RemoveMember {

--- a/src/types/roles.ts
+++ b/src/types/roles.ts
@@ -26,4 +26,9 @@ export type HasuraRole = "public";
  */
 export type UserRole = "platformAdmin";
 
+/**
+ * Roles which grant users a set of permissions relevant to the PlanX Editor. This currently includes Team Roles and admin level roles.
+ */
+export type EditorRole = TeamRole | UserRole;
+
 export type Role = TeamRole | HasuraRole | UserRole;

--- a/src/types/team.ts
+++ b/src/types/team.ts
@@ -1,5 +1,8 @@
 import { GeoJsonObject } from "geojson";
 
+import { Role } from "./roles";
+import { User } from "./user";
+
 export interface Team {
   id: number;
   name: string;
@@ -41,3 +44,7 @@ export interface NotifyPersonalisation {
   emailReplyToId: string;
   helpOpeningHours: string;
 }
+
+export type TeamMember = Omit<User, "teams" | "isPlatformAdmin"> & {
+  role: Role;
+};


### PR DESCRIPTION
## TLDR:
- Update upsertMember type interface to allow any `Role` rather than just `TeamRole`s.
- Add `TeamMember` type here so that it lives in planx-core along with other related types, rather than floating freely in planx-new 🐟 🌊 


## More context:

 Trello ticket: https://trello.com/c/piMcGsJa/2973-add-user-in-editor

I'm working on improving the 'optimistic update' part of my [PR on adding a new team editor](https://github.com/theopensystemslab/planx-new/pull/3500). As per @DafyddLlyr's suggestion, I'm trying to do this by storing the list of team members in the store, rather than [passing as a prop in the route like we do currently](https://github.com/theopensystemslab/planx-new/blob/e0bb2a95f89a72236df3800817bceaa72fcc8b83/editor.planx.uk/src/routes/teamMembers.tsx#L75).

I've done this by adding an `updateTeamMembers` setter to the `TeamStore` in [team.ts](https://github.com/theopensystemslab/planx-new/blob/e0bb2a95f89a72236df3800817bceaa72fcc8b83/editor.planx.uk/src/pages/FlowEditor/lib/store/team.ts#L31):
```
updateTeamMembers: async (teamMembers: TeamMember[]) => {
    const { teamId, $client } = get();
    for (const member of teamMembers) {
      const teamRole = member.role as TeamRole;
      await $client.team.addMember({
        userId: member.id,
        teamId,
        role: teamRole,
      });
    }
  },
  ```
However, this breaks when testing locally because the member `role` is not always a `TeamRole` ([see definition here](https://github.com/theopensystemslab/planx-core/blob/cd5d08de66d5d1f9a7ddeec8700b34cd9220b97b/src/types/roles.ts#L9)) - e.g. there could be a platformAdmin on the team.

Let me know if there is any good reason why I should not change the `upsertMember` interface to allow the more generic `Role` to fix this!