### PR TITLE
feat: adjust queries and types for new `submission_email` DB location

### DIFF
--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -101,7 +101,7 @@ export async function createTeam(
         $name: String!
         $slug: String!
         $domain: String
-        submissionEmail: String
+        $submissionEmail: String
         $settings: team_settings_insert_input!
         $theme: team_themes_insert_input!
       ) {

--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -23,6 +23,7 @@ interface NewTeam {
   slug: string;
   domain?: string;
   reference?: string;
+  submissionEmail?: string;
   settings?: Partial<TeamSettings>;
   theme?: Partial<TeamTheme>;
 }

--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -101,6 +101,7 @@ export async function createTeam(
         $name: String!
         $slug: String!
         $domain: String
+        submissionEmail: String
         $settings: team_settings_insert_input!
         $theme: team_themes_insert_input!
       ) {
@@ -109,6 +110,7 @@ export async function createTeam(
             name: $name
             slug: $slug
             domain: $domain
+            submission_email: $submissionEmail
             # Create empty records for associated tables - these can get populated later
             team_settings: { data: $settings }
             theme: { data: $theme }

--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -23,7 +23,6 @@ interface NewTeam {
   slug: string;
   domain?: string;
   reference?: string;
-  submissionEmail?: string;
   settings?: Partial<TeamSettings>;
   theme?: Partial<TeamTheme>;
 }
@@ -102,7 +101,6 @@ export async function createTeam(
         $name: String!
         $slug: String!
         $domain: String
-        $submissionEmail: String
         $settings: team_settings_insert_input!
         $theme: team_themes_insert_input!
       ) {
@@ -111,7 +109,6 @@ export async function createTeam(
             name: $name
             slug: $slug
             domain: $domain
-            submission_email: $submissionEmail
             # Create empty records for associated tables - these can get populated later
             team_settings: { data: $settings }
             theme: { data: $theme }
@@ -136,6 +133,7 @@ export async function createTeam(
         external_planning_site_url: newTeam?.settings?.externalPlanningSiteUrl,
         external_planning_site_name:
           newTeam?.settings?.externalPlanningSiteName,
+        submission_email: newTeam?.settings?.submissionEmail,
       },
       theme: {
         primary_colour: newTeam.theme?.primaryColour,
@@ -263,6 +261,7 @@ async function getBySlug(client: GraphQLClient, slug: string) {
             homepage: homepage
             externalPlanningSiteName: external_planning_site_name
             externalPlanningSiteUrl: external_planning_site_url
+            submissionEmail: submission_email
           }
         }
       }
@@ -440,6 +439,7 @@ async function updateTeamSettings(
         help_opening_hours: teamSettings.helpOpeningHours,
         email_reply_to_id: teamSettings.emailReplyToId,
         homepage: teamSettings.homepage,
+        submission_email: teamSettings.submissionEmail,
       },
     },
   );

--- a/src/types/team.ts
+++ b/src/types/team.ts
@@ -29,6 +29,7 @@ export interface TeamSettings {
   homepage?: string;
   externalPlanningSiteUrl: string;
   externalPlanningSiteName: string;
+  submissionEmail?: string;
 }
 
 export interface TeamIntegrations {


### PR DESCRIPTION
## What does this PR do?

I am adjusting team types and queries to suit the new location of `submission_email` created here: https://github.com/theopensystemslab/planx-new/pull/3554

This is to complete this Trello Ticket: https://trello.com/c/dVsTQpZZ/2984-allow-editors-to-see-update-their-teams-submission-email-in-team-settings-form

This adjustment should help the updating and maintaining of `submission_email` by teamAdmins.