### PR TITLE
fix: Fix CreateTeam mutation for submission email

### DIFF
--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -102,7 +102,6 @@ export async function createTeam(
         $name: String!
         $slug: String!
         $domain: String
-        $submissionEmail: String
         $settings: team_settings_insert_input!
         $theme: team_themes_insert_input!
       ) {
@@ -111,12 +110,8 @@ export async function createTeam(
             name: $name
             slug: $slug
             domain: $domain
-            submission_email: $submissionEmail
             # Create empty records for associated tables - these can get populated later
-            team_settings: {
-              data: $settings
-              submission_email: $submissionEmail
-            }
+            team_settings: { data: $settings }
             theme: { data: $theme }
             integrations: { data: {} }
           }

--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -113,7 +113,10 @@ export async function createTeam(
             domain: $domain
             submission_email: $submissionEmail
             # Create empty records for associated tables - these can get populated later
-            team_settings: { data: $settings }
+            team_settings: {
+              data: $settings
+              submission_email: $submissionEmail
+            }
             theme: { data: $theme }
             integrations: { data: {} }
           }


### PR DESCRIPTION
Remove `$submissionEmail` variable type from mutation to allow planx-new to add `submissionEmail` as argument passed into `createTeam()`

This fix enables the planx-new e2e regression fix.

https://github.com/theopensystemslab/planx-new/pull/3613