### PR TITLE
refactor: submission email tidy up

### DIFF
--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -23,7 +23,6 @@ interface NewTeam {
   slug: string;
   domain?: string;
   reference?: string;
-  submissionEmail?: string;
   settings?: Partial<TeamSettings>;
   theme?: Partial<TeamTheme>;
 }

--- a/src/types/team.ts
+++ b/src/types/team.ts
@@ -36,10 +36,11 @@ export interface TeamIntegrations {
   hasPlanningData: boolean;
 }
 
-export interface teamContactSettings {
-  helpEmail: string;
-  helpPhone: string;
-  emailReplyToId: string;
-  helpOpeningHours: string;
-  submissionEmail: string;
-}
+export type teamContactSettings = Pick<
+  TeamSettings,
+  | "helpEmail"
+  | "helpPhone"
+  | "emailReplyToId"
+  | "helpOpeningHours"
+  | "submissionEmail"
+>;

--- a/src/types/team.ts
+++ b/src/types/team.ts
@@ -36,7 +36,7 @@ export interface TeamIntegrations {
   hasPlanningData: boolean;
 }
 
-export type teamContactSettings = Pick<
+export type TeamContactSettings = Pick<
   TeamSettings,
   | "helpEmail"
   | "helpPhone"

--- a/src/types/team.ts
+++ b/src/types/team.ts
@@ -36,9 +36,10 @@ export interface TeamIntegrations {
   hasPlanningData: boolean;
 }
 
-export interface NotifyPersonalisation {
+export interface teamContactSettings {
   helpEmail: string;
   helpPhone: string;
   emailReplyToId: string;
   helpOpeningHours: string;
+  submissionEmail: string;
 }


### PR DESCRIPTION
## What does this PR do?

I am tidying up work done on submission email, where it was moved from the ``teams`` table to the `team_settings`` table

Changes focused on removing old fields and switching from ``NotifyPersonalisation`` in the type to ``TeamContactSettings`` and using `Pick` to pull them from the ``TeamSettings`` type. This felt right and in line with other changes.