### PR TITLE
fix: remove sub-email from getByTeamSlug

### DIFF
--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -261,7 +261,6 @@ async function getBySlug(client: GraphQLClient, slug: string) {
             homepage: homepage
             externalPlanningSiteName: external_planning_site_name
             externalPlanningSiteUrl: external_planning_site_url
-            submissionEmail: submission_email
           }
         }
       }


### PR DESCRIPTION
This was added to try and fix a bug with moveFlow, but it didn't fix in the way expected.

Currently fixed with another solution but may revisit for longer term fix.