### PR TITLE
chore: Add tags property to Node

### DIFF
--- a/src/types/flow.ts
+++ b/src/types/flow.ts
@@ -7,11 +7,14 @@ export type NodeId = string;
 
 export type Edges = Array<NodeId>;
 
+export const NodeTags = ["placeholder"] as const;
+
 export interface Node {
   id?: string;
   type?: ComponentType;
   edges?: Edges;
   data?: Record<string, Value>;
+  tags?: typeof NodeTags;
 }
 
 type RootNode = {


### PR DESCRIPTION
## What does this PR do?
 - Adds optional property `tags` to the `Node` type
 - Also exposes the list using `as const` so that we have the values at runtime (e.g. to populate a select or other UI component)

This is intentionally not held in `Node.data.tags` as `data` is using `Value` which, while accurate, is tricky to work with. I'd be keen to not expand this further, and actually property type the graph in a single place. Something I'm very keen to look at soon as I'm really feeling the limitations of having `data: any` recently! Once this is done, I don't think there's any reason we couldn't add `tags` into `data`.

I'm aware that `Node` is also defined in the frontend, and doesn't yet use this type - I'll take a look at this next.