### PR TITLE
fix: Get Team Settings response fix

### DIFF
--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -391,7 +391,8 @@ export async function getTeamSettings(client: GraphQLClient, slug: string) {
     `,
     { slug },
   );
-  return response.teamSettings[0];
+
+  return response;
 }
 
 async function updateTheme(

--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -371,7 +371,7 @@ async function getIntegrations({
 }
 
 export async function getTeamSettings(client: GraphQLClient, slug: string) {
-  const response: TeamSettings[] = await client.request(
+  const response: TeamSettings = await client.request(
     gql`
       query GetTeamSettings($slug: String!) {
         team_settings(where: { team: { slug: { _eq: $slug } } }) {

--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -371,10 +371,10 @@ async function getIntegrations({
 }
 
 export async function getTeamSettings(client: GraphQLClient, slug: string) {
-  const response: TeamSettings = await client.request(
+  const response: { teamSettings: TeamSettings[] } = await client.request(
     gql`
       query GetTeamSettings($slug: String!) {
-        team_settings(where: { team: { slug: { _eq: $slug } } }) {
+        teamSettings: team_settings(where: { team: { slug: { _eq: $slug } } }) {
           boundaryUrl: boundary_url
           boundaryBBox: boundary_bbox
           referenceCode: reference_code
@@ -392,7 +392,7 @@ export async function getTeamSettings(client: GraphQLClient, slug: string) {
     { slug },
   );
 
-  return response;
+  return response.teamSettings[0];
 }
 
 async function updateTheme(

--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -371,7 +371,7 @@ async function getIntegrations({
 }
 
 export async function getTeamSettings(client: GraphQLClient, slug: string) {
-  const response: { teamSettings: TeamSettings[] } = await client.request(
+  const response: TeamSettings[] = await client.request(
     gql`
       query GetTeamSettings($slug: String!) {
         team_settings(where: { team: { slug: { _eq: $slug } } }) {


### PR DESCRIPTION
In my last commit for the previous PR, we changed the query so it pulled directly from the `team_settings` table rather than the `teams` table:

```diff
  const response: { teamSettings: TeamSettings[] } = await client.request(
    gql`
      query GetTeamSettings($slug: String!) {
++      team_settings(where: { team: { slug: { _eq: $slug } } }) {
--       teams (where: { slug: { _eq: $slug } } }) {
--       teamSettings: team_settings{
          boundaryUrl: boundary_url
          ...
          submissionEmail: submission_email
        }
      }
    `,
    { slug },
  );
```

But, when I made this change, I forgot to redefine the table to a proper casing `teamSettings: team_settings` which led to issues in what this was returning as the return is:

```ts
  return response.teamSettings[0];
```