### PR TITLE
feat: Add tags field to node data (take 2)

### DIFF
--- a/src/models/result.ts
+++ b/src/models/result.ts
@@ -29,6 +29,8 @@ export function getResultData({
     text: "No result",
     description: "",
     category: flagSet,
+    color: "",
+    bgColor: "",
   };
 
   const SUPPORTED_DECISION_TYPES = [

--- a/src/types/flags.ts
+++ b/src/types/flags.ts
@@ -10,8 +10,8 @@ export const DEFAULT_FLAG_CATEGORY: FlagSet = "Planning permission";
 
 export interface Flag {
   text: string;
-  bgColor?: string;
-  color?: string;
+  bgColor: string;
+  color: string;
   category: FlagSet;
   description?: string;
   value?: string | undefined;

--- a/src/types/flow.ts
+++ b/src/types/flow.ts
@@ -7,9 +7,9 @@ export type NodeId = string;
 
 export type Edges = Array<NodeId>;
 
-export const NODE_TAGS = ["placeholder"] as const;
+type NodeTag = "placeholder";
 
-export type NodeTags = { tags?: typeof NODE_TAGS };
+export type NodeTags = { tags?: NodeTag[] };
 
 export type NodeData = Record<string, Value> & NodeTags;
 

--- a/src/types/flow.ts
+++ b/src/types/flow.ts
@@ -7,14 +7,17 @@ export type NodeId = string;
 
 export type Edges = Array<NodeId>;
 
-export const NodeTags = ["placeholder"] as const;
+export const NODE_TAGS = ["placeholder"] as const;
+
+export type NodeTags = { tags?: typeof NODE_TAGS };
+
+export type NodeData = Record<string, Value> & NodeTags;
 
 export interface Node {
-  id?: string;
+  id?: NodeId;
   type?: ComponentType;
   edges?: Edges;
-  data?: Record<string, Value>;
-  tags?: typeof NodeTags;
+  data?: NodeData;
 }
 
 type RootNode = {

--- a/src/types/flow.ts
+++ b/src/types/flow.ts
@@ -7,7 +7,7 @@ export type NodeId = string;
 
 export type Edges = Array<NodeId>;
 
-type NodeTag = "placeholder";
+export type NodeTag = "placeholder";
 
 export type NodeTags = { tags?: NodeTag[] };
 


### PR DESCRIPTION
Follow up to https://github.com/theopensystemslab/planx-core/pull/508

This PR changes the `tags` field to be a child of `data`. I've resolved the union issue with `Value` in planx-new here - https://github.com/theopensystemslab/planx-new/pull/3716

Using this method I've got a crude end-to-end solution working locally. PR incoming later today!

<img width="1438" alt="image" src="https://github.com/user-attachments/assets/76dfdff5-14c1-4354-bf10-2d6a5d65259e">
