### PR TITLE
fix: ensure Gov Pay reference is set for invite to pay applications in overview HTML and CSV

### DIFF
--- a/src/export/index.ts
+++ b/src/export/index.ts
@@ -79,17 +79,23 @@ export async function generateCSVData({
     );
   }
 
-  const passport = await getSessionPassport(client, sessionId);
-  if (!passport) {
+  const session = await getSessionById(client, sessionId);
+  if (!session)
+    throw new Error(
+      `Cannot find session ${sessionId} so cannot generate CSV Data`,
+    );
+
+  const { passport, govUkPayment } = session.data;
+  if (!passport)
     throw new Error(
       `Cannot find passport for session ${sessionId} so cannot generate CSV Data`,
     );
-  }
 
   return computeCSVData({
     sessionId,
     bopsData,
     passport,
+    govUkPayment,
   });
 }
 


### PR DESCRIPTION
Fixes #help-issues report from Friday afternoon: https://opendigitalplanning.slack.com/archives/C0241GWFG4B/p1728640257349149

Depending if the applicant self-paid or invited-to-pay, the payment info will be stored differently. We've been correctly accounting for this in the ODP Schema ([eg here](https://github.com/theopensystemslab/planx-core/blob/main/src/export/digitalPlanning/model.ts#L686-L698)) but NOT the CSV/Overview HTML formats and the reference number in invite to pay cases was failing to populate.

This fix correctly accounts for invite to pay cases, but ideally in the near future we'll do a larger refactor to generate the CSV & Overview HTML from the ODP Schema directly so we can remove these duplicated bespoke messy mappings!

