### PR TITLE
feat: add `demoUser` to `TeamRole` type

### DIFF
--- a/src/types/roles.ts
+++ b/src/types/roles.ts
@@ -23,7 +23,9 @@ export type HasuraRole = "public";
  * Roles granted by an authorised user's status, as opposed to their relationship to a team
  *
  * platformAdmin: The highest level of permission in PlanX, and can operate across all teams
+ *
+ * demoUser: Can only see their own flows in Demo team, and read-only access to Templates, ODP, and OSL teams
  */
-export type UserRole = "platformAdmin";
+export type UserRole = "platformAdmin" | "demoUser";
 
 export type Role = TeamRole | HasuraRole | UserRole;

--- a/src/types/roles.ts
+++ b/src/types/roles.ts
@@ -5,8 +5,10 @@
  * teamEditor: Full permissions for a particular team, read access to all others
  *
  * teamViewer: Read-only access to a team
+ *
+ * demoUser: Can only see their own flows in Demo team, and read-only access to Templates, ODP, and OSL teams
  */
-export type TeamRole = "teamEditor" | "teamViewer";
+export type TeamRole = "teamEditor" | "teamViewer" | "demoUser";
 
 /**
  * General roles used by Hasura
@@ -23,9 +25,7 @@ export type HasuraRole = "public";
  * Roles granted by an authorised user's status, as opposed to their relationship to a team
  *
  * platformAdmin: The highest level of permission in PlanX, and can operate across all teams
- *
- * demoUser: Can only see their own flows in Demo team, and read-only access to Templates, ODP, and OSL teams
  */
-export type UserRole = "platformAdmin" | "demoUser";
+export type UserRole = "platformAdmin";
 
 export type Role = TeamRole | HasuraRole | UserRole;


### PR DESCRIPTION
As part of the work here: https://trello.com/c/EfaEQRzK/2441-create-a-demo-workspace

I wanted to add a new team role for demo users. Assigning this to `TeamRole` over `UserRole` as `TeamRole` is used when fetching a users list of teams and it will make it easier in the future to promote them.

One of the connected future bits of work will be to alter the `is_staging_only` column for the demo users. 

I would be interested to know if we think this is the right approach. I am slightly hesitant because I feel the `demoUser` role is a global role that would restrict what a user can do and see, although the restrictions only really apply to a single team within PlanX, the "Demo" team, so I've started off with it as a `TeamRole` applied in the `team_members` table of the database.