### PR TITLE
chore: Error handling for `decrypt()`

### DIFF
--- a/src/utils/encryption.ts
+++ b/src/utils/encryption.ts
@@ -31,14 +31,19 @@ export function decrypt(
 ): string | undefined {
   if (!secret) return undefined;
 
-  const [encryptedToken, iv] = secret.split(":");
-  const decipher = crypto.createDecipheriv(
-    "AES-256-CBC",
-    Buffer.from(key, "utf-8"),
-    Buffer.from(iv, "hex"),
-  );
-  let decryptedToken = decipher.update(encryptedToken, "hex", "utf-8");
-  decryptedToken += decipher.final("utf-8");
+  try {
+    const [encryptedToken, iv] = secret.split(":");
+    const decipher = crypto.createDecipheriv(
+      "AES-256-CBC",
+      Buffer.from(key, "utf-8"),
+      Buffer.from(iv, "hex"),
+    );
+    let decryptedToken = decipher.update(encryptedToken, "hex", "utf-8");
+    decryptedToken += decipher.final("utf-8");
 
-  return decryptedToken;
+    return decryptedToken;
+  } catch (error) {
+    console.error("Failed to decrypt secret");
+    return undefined;
+  }
 }


### PR DESCRIPTION
## What does this PR do?
- Wraps `decrypt()` in a try/catch
- Currently, if decryption fails, an unhandled exception brings down Express
- This now ensures it's handled gracefully, and the consumer needs to check the existence of they keys (the function still maintains it's signature of returning `string | undefined` for a secret)

## To test 
 - Make a secret invalid, e.g. populate encrypted GovPay token as plaintext string `"abc123"`
 - Try to make payment
 - Graceful error handling in application, Docker logs capture issue
 - Example flow here on Pizza with an invalid GovPay key - https://3848.planx.pizza/epsom-and-ewell/test-pay-failure/published?analytics=false

<img width="473" alt="image" src="https://github.com/user-attachments/assets/58c10a27-40d1-4959-9666-3c5ac424268b">

<img width="793" alt="image" src="https://github.com/user-attachments/assets/760f3e8d-ff39-44d0-b14d-78192ff08cc5">

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/743682a8-3e33-4246-a117-199fbe19e9f4">
