### PR TITLE
feat: add `creator_id` to createFlow mutation

### DIFF
--- a/src/requests/flow.ts
+++ b/src/requests/flow.ts
@@ -13,6 +13,7 @@ export class FlowClient {
 
   async create(args: {
     teamId: number;
+    userId: number;
     slug: string;
     name: string;
     data?: object;
@@ -132,6 +133,7 @@ export async function createFlow(
   client: GraphQLClient,
   args: {
     teamId: number;
+    userId: number;
     slug: string;
     name: string;
     data?: object;
@@ -142,6 +144,7 @@ export async function createFlow(
     gql`
       mutation CreateFlow(
         $teamId: Int!
+        $userId: Int!
         $flowSlug: String!
         $flowName: String!
         $data: jsonb
@@ -149,6 +152,7 @@ export async function createFlow(
       ) {
         insert_flows_one(
           object: {
+            creator_id: $userId
             team_id: $teamId
             slug: $flowSlug
             name: $flowName
@@ -163,6 +167,7 @@ export async function createFlow(
     `,
     {
       teamId: args.teamId,
+      userId: args.userId,
       flowSlug: args.slug,
       flowName: args.name,
       data: args.data,


### PR DESCRIPTION
To support the use of `creator_id` in the demo workspace ticket: https://trello.com/c/EfaEQRzK/2441-create-a-demo-workspace

I am updating the CreateFlow mutation to take in a `userId` and add it to the `creator_id` column of a flow.