### PR TITLE
chore: update ODP Schema `proposal.description` mappings based on new LDC inputs

### DIFF
--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -749,6 +749,19 @@ export class DigitalPlanning {
   }
 
   private getProposal(): Proposal {
+    // LDC app types specifically ask for `proposal.description` across various separate input fields depending
+    const ldcDescriptionFns = [
+      this.passport.data?.["proposal.buildingOperations.details"] as string,
+      this.passport.data?.["proposal.changeOfUse.details"] as string,
+      this.passport.data?.["proposal.existingWorks.details"] as string,
+      this.passport.data?.["proposal.existingUse.details"] as string,
+    ];
+    const proposalDescription = this.passport.data?.[
+      "application.type"
+    ]?.[0].startsWith("ldc")
+      ? ldcDescriptionFns.filter(Boolean).join("; ")
+      : (this.passport.data?.["proposal.description"] as string);
+
     const baseProposal: BaseProposal = {
       projectType: (
         (this.passport.data?.["proposal.projectType"] as string[]) || []
@@ -758,9 +771,7 @@ export class DigitalPlanning {
           description: this.findDescriptionFromValue("ProjectType", project),
         } as ProjectType;
       }),
-      description:
-        (this.passport.data?.["proposal.description"] as string) ||
-        "Not provided",
+      description: proposalDescription || "Not provided",
       date: {
         start: (this.passport.data?.["proposal.started.date"] ||
           this.passport.data?.["proposal.start.date"]) as string,


### PR DESCRIPTION
From August:
> Schema currently expects a `proposal.description` for LDCs. During our review we learned that LDCs have project and app type specific requirements, so that we now capture these as various `.details` inputs instead.
> - if `application.type` is `ldc.proposed`: concatenate `proposal.buildingOperations.details` and `proposal.changeOfUse.details` and map result to `proposal.description`
> - if `application.type` is `ldc.existing`: concatenate `proposal.existingWorks.details` and `proposal.existingUse.details` and map result to `proposal.description`
> 
> Both app types can have one of or both of these, and it's never both app types, so maybe ignore the app type condition and concatenate all available `.details`?

In a future release, it'd be ideal to break these fields out rather than concatenate and make them optional/required based on their application type - but this updated mapping helps bridge the content <> integrations gap while we proceed with pilot testing using v0.7