### PR TITLE
fix: Correctly track portal IDs when indexing nodes

### DIFF
--- a/src/models/session/logic.test.ts
+++ b/src/models/session/logic.test.ts
@@ -45,34 +45,40 @@ describe("sortFlow", () => {
     const sortedFlowNodes: OrderedFlow = sortFlow(portals.flow);
 
     it("doesn't assign an internal portal ID for nodes on the route, before entering a portal", () => {
-      const nodeOnRoot = sortedFlowNodes.find(({ id }) => id === "kReDM5AWwf");
-      expect(nodeOnRoot?.internalPortalId).not.toBeDefined();
+      const rootQuestionOne = sortedFlowNodes.find(
+        ({ id }) => id === "rootQuestionOne",
+      );
+      expect(rootQuestionOne).toBeDefined();
+      expect(rootQuestionOne?.internalPortalId).not.toBeDefined();
     });
 
     it("assigns the correct internal portal id, nested one level", () => {
-      const nodeInFirstPortal = sortedFlowNodes.find(
-        ({ id }) => id === "sGJEsJDLp6",
+      const levelOneQuestionOne = sortedFlowNodes.find(
+        ({ id }) => id === "levelOneQuestionOne",
       );
-      expect(nodeInFirstPortal?.internalPortalId).toEqual("levelOne");
+      expect(levelOneQuestionOne?.internalPortalId).toEqual("levelOne");
     });
 
     it("assigns the correct internal portal id, nested two levels", () => {
-      const nodeInFirstPortal = sortedFlowNodes.find(
-        ({ id }) => id === "DzSOjpW0pc",
+      const levelTwoQuestion = sortedFlowNodes.find(
+        ({ id }) => id === "levelTwoQuestion",
       );
-      expect(nodeInFirstPortal?.internalPortalId).toEqual("levelTwo");
+      expect(levelTwoQuestion?.internalPortalId).toEqual("levelTwo");
     });
 
     it("assigns the correct internal portal id, after exiting a nested portal", () => {
-      const nodeInFirstPortal = sortedFlowNodes.find(
-        ({ id }) => id === "rwkfyRB9io",
+      const levelOneQuestionTwo = sortedFlowNodes.find(
+        ({ id }) => id === "levelOneQuestionTwo",
       );
-      expect(nodeInFirstPortal?.internalPortalId).toEqual("levelOne");
+      expect(levelOneQuestionTwo?.internalPortalId).toEqual("levelOne");
     });
 
     it("doesn't assign an internal portal ID after exiting all portals", () => {
-      const nodeOnRoot = sortedFlowNodes.find(({ id }) => id === "LNjFPmokA4");
-      expect(nodeOnRoot?.internalPortalId).not.toBeDefined();
+      const rootQuestionTwo = sortedFlowNodes.find(
+        ({ id }) => id === "rootQuestionTwo",
+      );
+      expect(rootQuestionTwo).toBeDefined();
+      expect(rootQuestionTwo?.internalPortalId).not.toBeDefined();
     });
   });
 });

--- a/src/models/session/logic.test.ts
+++ b/src/models/session/logic.test.ts
@@ -1,6 +1,7 @@
 import { type OrderedBreadcrumbs, type OrderedFlow } from "../../types";
 import { getPathForNode, sortBreadcrumbs, sortFlow } from "./logic";
 import * as complex from "./mocks/complex-flow-breadcrumbs";
+import * as portals from "./mocks/flow-with-internal-portals";
 import * as large from "./mocks/large-real-life-flow";
 import * as sectioned from "./mocks/section-flow-breadcrumbs";
 import * as simple from "./mocks/simple-flow-breadcrumbs";
@@ -38,6 +39,41 @@ describe("sortFlow", () => {
         },
       });
     }).toThrow();
+  });
+
+  describe("recording internal portal ids", () => {
+    const sortedFlowNodes: OrderedFlow = sortFlow(portals.flow);
+
+    it("doesn't assign an internal portal ID for nodes on the route, before entering a portal", () => {
+      const nodeOnRoot = sortedFlowNodes.find(({ id }) => id === "kReDM5AWwf");
+      expect(nodeOnRoot?.internalPortalId).not.toBeDefined();
+    });
+
+    it("assigns the correct internal portal id, nested one level", () => {
+      const nodeInFirstPortal = sortedFlowNodes.find(
+        ({ id }) => id === "sGJEsJDLp6",
+      );
+      expect(nodeInFirstPortal?.internalPortalId).toEqual("levelOne");
+    });
+
+    it("assigns the correct internal portal id, nested two levels", () => {
+      const nodeInFirstPortal = sortedFlowNodes.find(
+        ({ id }) => id === "DzSOjpW0pc",
+      );
+      expect(nodeInFirstPortal?.internalPortalId).toEqual("levelTwo");
+    });
+
+    it("assigns the correct internal portal id, after exiting a nested portal", () => {
+      const nodeInFirstPortal = sortedFlowNodes.find(
+        ({ id }) => id === "rwkfyRB9io",
+      );
+      expect(nodeInFirstPortal?.internalPortalId).toEqual("levelOne");
+    });
+
+    it("doesn't assign an internal portal ID after exiting all portals", () => {
+      const nodeOnRoot = sortedFlowNodes.find(({ id }) => id === "LNjFPmokA4");
+      expect(nodeOnRoot?.internalPortalId).not.toBeDefined();
+    });
   });
 });
 

--- a/src/models/session/mocks/flow-with-internal-portals.ts
+++ b/src/models/session/mocks/flow-with-internal-portals.ts
@@ -2,9 +2,9 @@ import { ComponentType, FlowGraph } from "../../../types";
 
 export const flow: FlowGraph = {
   _root: {
-    edges: ["kReDM5AWwf", "levelOne", "DJDsTYVeZG"],
+    edges: ["rootQuestionOne", "levelOne", "rootQuestionTwo"],
   },
-  DJDsTYVeZG: {
+  rootQuestionTwo: {
     data: {
       fn: "animal",
       tags: [],
@@ -12,30 +12,30 @@ export const flow: FlowGraph = {
       neverAutoAnswer: false,
     },
     type: ComponentType.Question,
-    edges: ["LNjFPmokA4"],
+    edges: ["rootAnswerTwo"],
   },
-  DzSOjpW0pc: {
+  levelTwoAnswer: {
     data: {
       val: "capybara",
       text: "Capybara",
     },
     type: ComponentType.Answer,
   },
-  IAtSgHREeb: {
+  rootAnswerOne: {
     data: {
       val: "aardvark",
       text: "aardvark",
     },
     type: ComponentType.Answer,
   },
-  LNjFPmokA4: {
+  rootAnswerTwo: {
     data: {
       val: "elephant",
       text: "Elephant",
     },
     type: ComponentType.Answer,
   },
-  VR420vch1P: {
+  levelOneQuestionOne: {
     data: {
       fn: "animal",
       tags: [],
@@ -43,25 +43,25 @@ export const flow: FlowGraph = {
       neverAutoAnswer: false,
     },
     type: ComponentType.Question,
-    edges: ["sGJEsJDLp6"],
+    edges: ["levelOneAnswerOne"],
   },
   levelTwo: {
     data: {
       text: "level two",
     },
     type: ComponentType.InternalPortal,
-    edges: ["fcTNTjbLdl"],
+    edges: ["levelTwoQuestion"],
   },
-  fcTNTjbLdl: {
+  levelTwoQuestion: {
     data: {
       fn: "animal",
       text: "Capybara",
       neverAutoAnswer: false,
     },
     type: ComponentType.Question,
-    edges: ["DzSOjpW0pc"],
+    edges: ["levelTwoAnswer"],
   },
-  kReDM5AWwf: {
+  rootQuestionOne: {
     data: {
       fn: "animal",
       tags: [],
@@ -69,36 +69,36 @@ export const flow: FlowGraph = {
       neverAutoAnswer: false,
     },
     type: ComponentType.Question,
-    edges: ["IAtSgHREeb"],
+    edges: ["rootAnswerOne"],
   },
   levelOne: {
     data: {
       text: "level one",
     },
     type: ComponentType.InternalPortal,
-    edges: ["VR420vch1P", "levelTwo", "ui15uRJqfs"],
+    edges: ["levelOneQuestionOne", "levelTwo", "levelOneQuestionTwo"],
   },
-  rwkfyRB9io: {
+  levelOneAnswerTwo: {
     data: {
       val: "donkey",
       text: "Donkey",
     },
     type: ComponentType.Answer,
   },
-  sGJEsJDLp6: {
+  levelOneAnswerOne: {
     data: {
       val: "baboon",
       text: "Baboon",
     },
     type: ComponentType.Answer,
   },
-  ui15uRJqfs: {
+  levelOneQuestionTwo: {
     data: {
       fn: "animal",
       text: "Donkey",
       neverAutoAnswer: false,
     },
     type: ComponentType.Question,
-    edges: ["rwkfyRB9io"],
+    edges: ["levelOneAnswerTwo"],
   },
 };

--- a/src/models/session/mocks/flow-with-internal-portals.ts
+++ b/src/models/session/mocks/flow-with-internal-portals.ts
@@ -1,0 +1,104 @@
+import { ComponentType, FlowGraph } from "../../../types";
+
+export const flow: FlowGraph = {
+  _root: {
+    edges: ["kReDM5AWwf", "levelOne", "DJDsTYVeZG"],
+  },
+  DJDsTYVeZG: {
+    data: {
+      fn: "animal",
+      tags: [],
+      text: "Elephant",
+      neverAutoAnswer: false,
+    },
+    type: ComponentType.Question,
+    edges: ["LNjFPmokA4"],
+  },
+  DzSOjpW0pc: {
+    data: {
+      val: "capybara",
+      text: "Capybara",
+    },
+    type: ComponentType.Answer,
+  },
+  IAtSgHREeb: {
+    data: {
+      val: "aardvark",
+      text: "aardvark",
+    },
+    type: ComponentType.Answer,
+  },
+  LNjFPmokA4: {
+    data: {
+      val: "elephant",
+      text: "Elephant",
+    },
+    type: ComponentType.Answer,
+  },
+  VR420vch1P: {
+    data: {
+      fn: "animal",
+      tags: [],
+      text: "Baboon",
+      neverAutoAnswer: false,
+    },
+    type: ComponentType.Question,
+    edges: ["sGJEsJDLp6"],
+  },
+  levelTwo: {
+    data: {
+      text: "level two",
+    },
+    type: ComponentType.InternalPortal,
+    edges: ["fcTNTjbLdl"],
+  },
+  fcTNTjbLdl: {
+    data: {
+      fn: "animal",
+      text: "Capybara",
+      neverAutoAnswer: false,
+    },
+    type: ComponentType.Question,
+    edges: ["DzSOjpW0pc"],
+  },
+  kReDM5AWwf: {
+    data: {
+      fn: "animal",
+      tags: [],
+      text: "Aardvark",
+      neverAutoAnswer: false,
+    },
+    type: ComponentType.Question,
+    edges: ["IAtSgHREeb"],
+  },
+  levelOne: {
+    data: {
+      text: "level one",
+    },
+    type: ComponentType.InternalPortal,
+    edges: ["VR420vch1P", "levelTwo", "ui15uRJqfs"],
+  },
+  rwkfyRB9io: {
+    data: {
+      val: "donkey",
+      text: "Donkey",
+    },
+    type: ComponentType.Answer,
+  },
+  sGJEsJDLp6: {
+    data: {
+      val: "baboon",
+      text: "Baboon",
+    },
+    type: ComponentType.Answer,
+  },
+  ui15uRJqfs: {
+    data: {
+      fn: "animal",
+      text: "Donkey",
+      neverAutoAnswer: false,
+    },
+    type: ComponentType.Question,
+    edges: ["rwkfyRB9io"],
+  },
+};


### PR DESCRIPTION
## What does this PR do?
 - Fixes issue described here https://opensystemslab.slack.com/archives/C01E3AC0C03/p1730805531747509 (OSL Slack)
 - Creates a stack of portal ids when indexing nodes
   - Add to the stack when we hit a portal
   - Remove from the stack when we exit
 - This means that we now correctly assign the `internalPortalId` to all indexed nodes.

Implemented in https://github.com/theopensystemslab/planx-new/pull/3914