### PR TITLE
feat: Generate `QuestionAndResponse[]` for `List` and `Page` components

### DIFF
--- a/src/export/bops/index.ts
+++ b/src/export/bops/index.ts
@@ -49,8 +49,6 @@ const bopsDictionary = {
 function isTypeForBopsPayload(type?: ComponentType) {
   if (!type) return false;
 
-  //To-Do Set MapAndLabel to True once we know shape of BOPs data
-
   switch (type) {
     case ComponentType.Answer:
     case ComponentType.Calculate:
@@ -58,13 +56,14 @@ function isTypeForBopsPayload(type?: ComponentType) {
     case ComponentType.Content:
     case ComponentType.DrawBoundary:
     case ComponentType.ExternalPortal:
-    case ComponentType.Feedback:
+    case ComponentType.Feedback: // TODO
     case ComponentType.FileUpload:
     case ComponentType.FileUploadAndLabel:
     case ComponentType.Filter:
     case ComponentType.FindProperty:
     case ComponentType.Flow:
     case ComponentType.InternalPortal:
+    case ComponentType.MapAndLabel: // TODO - Parse GeoJSON FeatureCollection
     case ComponentType.NextSteps:
     case ComponentType.Notice:
     case ComponentType.Pay:
@@ -83,7 +82,6 @@ function isTypeForBopsPayload(type?: ComponentType) {
     case ComponentType.ContactInput:
     case ComponentType.DateInput:
     case ComponentType.List:
-    case ComponentType.MapAndLabel:
     case ComponentType.NumberInput:
     case ComponentType.Page:
     case ComponentType.Question:

--- a/src/export/bops/schema/utils.ts
+++ b/src/export/bops/schema/utils.ts
@@ -59,27 +59,19 @@ export const parseSchemaResponses = (fn: string, crumb: EnrichedCrumb) => {
  * Format a question string for this granular field
  */
 const formatQuestion = ({
-  nodeTitle,
   fieldTitle,
   crumb,
   schemaType,
   index,
 }: {
-  nodeTitle: string;
   fieldTitle: string;
   crumb: EnrichedCrumb;
   schemaType: string;
   index: number;
-}) => {
-  // Prepend node title
-  let question = `[${nodeTitle}] ${fieldTitle}`;
-
-  // Append item number
-  if (crumb.type !== ComponentType.Page)
-    question += ` (${schemaType} ${index + 1})`;
-
-  return question;
-};
+}) =>
+  crumb.type === ComponentType.Page
+    ? fieldTitle
+    : `[${schemaType} ${index + 1}] ${fieldTitle}`;
 
 export const formatResponses = (
   schemaResponses: string | number | string[] | Record<string, unknown>[],
@@ -121,7 +113,6 @@ export const getSchemaProposalDetails = (
       (schemaResponse, index) =>
         fields.map((field) => {
           const question = formatQuestion({
-            nodeTitle: nodeData.title,
             fieldTitle: field.data.title,
             schemaType: nodeData.schema.type,
             crumb,

--- a/src/export/bops/schema/utils.ts
+++ b/src/export/bops/schema/utils.ts
@@ -1,0 +1,125 @@
+import { z } from "zod";
+
+import {
+  ComponentType,
+  EnrichedCrumb,
+  Node,
+  QuestionAndResponses,
+  Response,
+} from "../../../types";
+
+export const isSchemaType = (type: ComponentType) =>
+  [ComponentType.Page, ComponentType.List, ComponentType.MapAndLabel].includes(
+    type,
+  );
+
+/**
+ * Parse the data of a node which uses a schema for responses
+ */
+const parseNodeData = (node: Node) => {
+  const componentSchema = z.object({
+    fn: z.string(),
+    title: z.string(),
+    schema: z.object({
+      type: z.string(),
+      fields: z.array(
+        z.object({
+          data: z.object({
+            fn: z.string(),
+            title: z.string(),
+          }),
+        }),
+      ),
+    }),
+  });
+  const nodeData = componentSchema.parse(node.data);
+  return nodeData;
+};
+
+/**
+ * Parse the breadcrumb (SchemaResponse) which contains the user's responses
+ */
+export const parseSchemaResponses = (fn: string, crumb: EnrichedCrumb) => {
+  const crumbDataSchema = z.object({
+    [fn]: z.array(
+      z.record(
+        z.union([
+          z.string(),
+          z.number(),
+          z.array(z.string()),
+          z.record(z.unknown()),
+        ]),
+      ),
+    ),
+  });
+  const crumbData = crumbDataSchema.parse(crumb.data);
+  const schemaResponses = crumbData[fn];
+  return schemaResponses;
+};
+
+/**
+ * Format a question string for this granular field
+ */
+const formatQuestion = ({
+  nodeTitle,
+  fieldTitle,
+  crumb,
+  schemaType,
+  index,
+}: {
+  nodeTitle: string;
+  fieldTitle: string;
+  crumb: EnrichedCrumb;
+  schemaType: string;
+  index: number;
+}) => {
+  let question = `${nodeTitle} - ${fieldTitle}`;
+
+  if (crumb.type !== ComponentType.Page)
+    question += ` (${schemaType} ${index + 1})`;
+
+  return question;
+};
+
+export const formatResponses = (
+  schemaResponses: string | number | string[] | Record<string, unknown>,
+): Response[] =>
+  Array.isArray(schemaResponses)
+    ? schemaResponses.map((value) => ({ value: JSON.stringify(value) }))
+    : [{ value: JSON.stringify(schemaResponses) }];
+
+/**
+ * Components which rely on an internal schema must be unpacked
+ * Each component can provide multiple responses, with multiple fields, with (potentially) multiple answers
+ */
+export const getSchemaProposalDetails = (
+  crumb: EnrichedCrumb,
+  node: Node,
+  metadata: QuestionAndResponses["metadata"],
+): QuestionAndResponses[] => {
+  try {
+    const nodeData = parseNodeData(node);
+    const schemaResponses = parseSchemaResponses(nodeData.fn, crumb);
+    const fields = nodeData.schema.fields;
+
+    const proposalDetails: QuestionAndResponses[] = schemaResponses.flatMap(
+      (schemaResponse, index) =>
+        fields.map((field) => {
+          const question = formatQuestion({
+            nodeTitle: nodeData.title,
+            fieldTitle: field.data.title,
+            schemaType: nodeData.schema.type,
+            crumb,
+            index,
+          });
+          const responses = formatResponses(schemaResponse[field.data.fn]);
+
+          return { question, responses, metadata };
+        }),
+    );
+
+    return proposalDetails;
+  } catch (error) {
+    throw new Error(`Failed to get schema proposal details. Error: ${error}`);
+  }
+};

--- a/src/export/bops/tests/proposalDetails.test.ts
+++ b/src/export/bops/tests/proposalDetails.test.ts
@@ -1,4 +1,8 @@
-import type { QuestionAndResponses } from "../../../types";
+import type {
+  Breadcrumbs,
+  FlowGraph,
+  QuestionAndResponses,
+} from "../../../types";
 import { formatProposalDetails } from "../index";
 import { flowWithThreeSections, sectionBreadcrumbs } from "../mocks/sections";
 
@@ -393,5 +397,1402 @@ describe("Flow without sections", () => {
     result.proposalDetails.forEach((detail) => {
       expect(detail.metadata).not.toHaveProperty("section_name");
     });
+  });
+});
+
+describe("Components which use an internal schema", () => {
+  test("Page component", () => {
+    const mockFlow: FlowGraph = {
+      _root: {
+        edges: ["PQKZF4HWmv"],
+      },
+      PQKZF4HWmv: {
+        type: 810,
+        data: {
+          fn: "mockData",
+          title: "This is a page component",
+          schemaName: "Advert consent",
+          schema: {
+            type: "Proposed advertisements",
+            fields: [
+              {
+                type: "number",
+                data: {
+                  title: "How many fascia signs are you applying for?",
+                  fn: "fascia",
+                  allowNegatives: false,
+                },
+              },
+              {
+                type: "number",
+                data: {
+                  title:
+                    "How many projecting or hanging signs are you applying for?",
+                  fn: "projecting",
+                  allowNegatives: false,
+                },
+              },
+              {
+                type: "number",
+                data: {
+                  title: "How many hoardings are you applying for?",
+                  fn: "hoarding",
+                  allowNegatives: false,
+                },
+              },
+              {
+                type: "number",
+                data: {
+                  title: "How many other advertisements are you applying for?",
+                  fn: "other",
+                  allowNegatives: false,
+                },
+              },
+            ],
+            min: 1,
+            max: 1,
+          },
+          tags: [],
+        },
+      },
+    };
+
+    const mockBreadcrumbs: Breadcrumbs = {
+      PQKZF4HWmv: {
+        auto: false,
+        data: {
+          mockData: [
+            {
+              fascia: 1,
+              projecting: 2,
+              hoarding: 3,
+              other: 4,
+            },
+          ],
+          "mockData.fascia": 1,
+          "mockData.projecting": 2,
+          "mockData.hoarding": 3,
+          "mockData.other": 4,
+        },
+      },
+    };
+
+    const expected = {
+      feedback: undefined,
+      proposalDetails: [
+        {
+          metadata: {},
+          question:
+            "[This is a page component] How many fascia signs are you applying for?",
+          responses: [{ value: "1" }],
+        },
+        {
+          metadata: {},
+          question:
+            "[This is a page component] How many projecting or hanging signs are you applying for?",
+          responses: [{ value: "2" }],
+        },
+        {
+          metadata: {},
+          question:
+            "[This is a page component] How many hoardings are you applying for?",
+          responses: [{ value: "3" }],
+        },
+        {
+          metadata: {},
+          question:
+            "[This is a page component] How many other advertisements are you applying for?",
+          responses: [{ value: "4" }],
+        },
+      ],
+    };
+
+    const actual = formatProposalDetails({
+      flow: mockFlow,
+      breadcrumbs: mockBreadcrumbs,
+    });
+
+    // Tested behaviour -
+    // - Response values are correct
+    // - Response values are cast to strings
+    // - Component title is prepended to questions
+    expect(actual).toStrictEqual(expected);
+  });
+
+  test("List component", () => {
+    const mockFlow: FlowGraph = {
+      _root: {
+        edges: ["oOD6xqekEk"],
+      },
+      oOD6xqekEk: {
+        type: 800,
+        data: {
+          fn: "mockData",
+          title: "Residential units (GLA) - Gained",
+          schemaName: "Residential units (GLA) - Gained",
+          schema: {
+            type: "Gained residential unit type",
+            fields: [
+              {
+                type: "number",
+                data: {
+                  title: "Number of units of this type",
+                  description:
+                    "This is the number of units of this type that are gained.",
+                  fn: "identicalUnits",
+                  allowNegatives: false,
+                },
+              },
+              {
+                type: "question",
+                data: {
+                  title: "What best describes this unit?",
+                  fn: "type",
+                  options: [
+                    {
+                      id: "terraced",
+                      data: {
+                        text: "Terraced home",
+                        val: "terraced",
+                      },
+                    },
+                    {
+                      id: "semiDetached",
+                      data: {
+                        text: "Semi detached home",
+                        val: "semiDetached",
+                      },
+                    },
+                    {
+                      id: "detached",
+                      data: {
+                        text: "Detached home",
+                        val: "detached",
+                      },
+                    },
+                    {
+                      id: "flat",
+                      data: {
+                        text: "Flat/apartment or maisonette",
+                        val: "flat",
+                      },
+                    },
+                    {
+                      id: "LW",
+                      data: {
+                        text: "Live/work unit",
+                        val: "LW",
+                      },
+                    },
+                    {
+                      id: "cluster",
+                      data: {
+                        text: "Cluster flat",
+                        val: "cluster",
+                      },
+                    },
+                    {
+                      id: "studio",
+                      data: {
+                        text: "Studio or bedsit",
+                        val: "studio",
+                      },
+                    },
+                    {
+                      id: "coLiving",
+                      data: {
+                        text: "Co living unit",
+                        val: "coLiving",
+                      },
+                    },
+                    {
+                      id: "hostel",
+                      data: {
+                        text: "Hostel room",
+                        val: "hostel",
+                      },
+                    },
+                    {
+                      id: "HMO",
+                      data: {
+                        text: "HMO",
+                        val: "HMO",
+                      },
+                    },
+                    {
+                      id: "student",
+                      data: {
+                        text: "Student accommodation",
+                        val: "student",
+                      },
+                    },
+                    {
+                      id: "other",
+                      data: {
+                        text: "Other",
+                        val: "other",
+                      },
+                    },
+                  ],
+                },
+              },
+              {
+                type: "number",
+                data: {
+                  title:
+                    "What will be the Gross Internal Floor Area (GIA) of this unit?",
+                  units: "m²",
+                  fn: "area",
+                  allowNegatives: false,
+                },
+              },
+              {
+                type: "number",
+                data: {
+                  title: "How many habitable rooms will this unit have?",
+                  fn: "habitable",
+                  allowNegatives: false,
+                },
+              },
+              {
+                type: "number",
+                data: {
+                  title: "How many bedrooms will this unit have?",
+                  fn: "bedrooms",
+                  allowNegatives: false,
+                },
+              },
+              {
+                type: "question",
+                data: {
+                  title: "What best describes the tenure of this unit?",
+                  fn: "tenure",
+                  options: [
+                    {
+                      id: "LAR",
+                      data: {
+                        text: "London Affordable Rent",
+                        val: "LAR",
+                      },
+                    },
+                    {
+                      id: "AR",
+                      data: {
+                        text: "Affordable rent (not at LAR benchmark rents)",
+                        val: "AR",
+                      },
+                    },
+                    {
+                      id: "SR",
+                      data: {
+                        text: "Social rent",
+                        val: "SR",
+                      },
+                    },
+                    {
+                      id: "LRR",
+                      data: {
+                        text: "London Living Rent",
+                        val: "LRR",
+                      },
+                    },
+                    {
+                      id: "sharedEquity",
+                      data: {
+                        text: "Shared equity",
+                        val: "sharedEquity",
+                      },
+                    },
+                    {
+                      id: "LSO",
+                      data: {
+                        text: "London Shared Ownership",
+                        val: "LSO",
+                      },
+                    },
+                    {
+                      id: "DMS",
+                      data: {
+                        text: "Discount market sale",
+                        val: "DMS",
+                      },
+                    },
+                    {
+                      id: "DMR",
+                      data: {
+                        text: "Discount market rent",
+                        val: "DMR",
+                      },
+                    },
+                    {
+                      id: "DMRLLR",
+                      data: {
+                        text: "Discount market rent (charged at London Living Rents)",
+                        val: "DMRLLR",
+                      },
+                    },
+                    {
+                      id: "marketForRent",
+                      data: {
+                        text: "Market for rent",
+                        val: "marketForRent",
+                      },
+                    },
+                    {
+                      id: "SH",
+                      data: {
+                        text: "Starter homes",
+                        val: "SH",
+                      },
+                    },
+                    {
+                      id: "selfCustomBuild",
+                      data: {
+                        text: "Self-build and custom build",
+                        val: "selfCustomBuild",
+                      },
+                    },
+                    {
+                      id: "marketForSale",
+                      data: {
+                        text: "Market for sale",
+                        val: "marketForSale",
+                      },
+                    },
+                    {
+                      id: "other",
+                      data: {
+                        text: "Other",
+                        val: "other",
+                      },
+                    },
+                  ],
+                },
+              },
+              {
+                type: "question",
+                data: {
+                  title: "What best describes the provider of this unit?",
+                  fn: "provider",
+                  options: [
+                    {
+                      id: "private",
+                      data: {
+                        text: "Private",
+                        val: "private",
+                      },
+                    },
+                    {
+                      id: "privateRented",
+                      data: {
+                        text: "Private rented sector",
+                        val: "privateRented",
+                      },
+                    },
+                    {
+                      id: "HA",
+                      data: {
+                        text: "Housing association",
+                        val: "HA",
+                      },
+                    },
+                    {
+                      id: "LA",
+                      data: {
+                        text: "Local authority",
+                        val: "LA",
+                      },
+                    },
+                    {
+                      id: "publicAuthority",
+                      data: {
+                        text: "Other public authority",
+                        val: "publicAuthority",
+                      },
+                    },
+                    {
+                      id: "councilDelivery",
+                      data: {
+                        text: "Council delivery company",
+                        val: "councilDelivery",
+                      },
+                    },
+                    {
+                      id: "councilBuildToRent",
+                      data: {
+                        text: "Council delivered build to rent",
+                        val: "councilBuildToRent",
+                      },
+                    },
+                    {
+                      id: "affordableHousing",
+                      data: {
+                        text: "Other affordable housing provider",
+                        val: "affordableHousing",
+                      },
+                    },
+                    {
+                      id: "selfBuild",
+                      data: {
+                        text: "Self-build",
+                        val: "selfBuild",
+                      },
+                    },
+                  ],
+                },
+              },
+              {
+                type: "checklist",
+                data: {
+                  title:
+                    "Will this unit be compliant with any of the following?",
+                  fn: "compliance",
+                  options: [
+                    {
+                      id: "m42",
+                      data: {
+                        text: "Part M4(2) of the Building Regulations 2010",
+                      },
+                    },
+                    {
+                      id: "m432a",
+                      data: {
+                        text: "Part M4(3)(2a) of the Building Regulations 2010",
+                      },
+                    },
+                    {
+                      id: "m432b",
+                      data: {
+                        text: "Part M4(3)(2b) of the Building Regulations 2010",
+                      },
+                    },
+                    {
+                      id: "none",
+                      data: {
+                        text: "None of these",
+                      },
+                    },
+                  ],
+                },
+              },
+              {
+                type: "question",
+                data: {
+                  title: "Will this unit be built on garden land?",
+                  fn: "garden",
+                  options: [
+                    {
+                      id: "true",
+                      data: {
+                        text: "Yes",
+                        val: "true",
+                      },
+                    },
+                    {
+                      id: "false",
+                      data: {
+                        text: "No",
+                        val: "false",
+                      },
+                    },
+                  ],
+                },
+              },
+              {
+                type: "question",
+                data: {
+                  title: "Will this unit provide sheltered accommodation?",
+                  fn: "sheltered",
+                  options: [
+                    {
+                      id: "true",
+                      data: {
+                        text: "Yes",
+                        val: "true",
+                      },
+                    },
+                    {
+                      id: "false",
+                      data: {
+                        text: "No",
+                        val: "false",
+                      },
+                    },
+                  ],
+                },
+              },
+              {
+                type: "question",
+                data: {
+                  title: "Is this unit specifically designed for older people?",
+                  fn: "olderPersons",
+                  options: [
+                    {
+                      id: "true",
+                      data: {
+                        text: "Yes",
+                        val: "true",
+                      },
+                    },
+                    {
+                      id: "false",
+                      data: {
+                        text: "No",
+                        val: "false",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+            min: 1,
+          },
+        },
+      },
+    };
+
+    const mockBreadcrumbs: Breadcrumbs = {
+      oOD6xqekEk: {
+        auto: false,
+        data: {
+          mockData: [
+            {
+              identicalUnits: 3,
+              type: "flat",
+              area: 3,
+              habitable: 6,
+              bedrooms: 3,
+              tenure: "DMS",
+              provider: "private",
+              compliance: ["m42", "m432a", "m432b"],
+              garden: "false",
+              sheltered: "true",
+              olderPersons: "true",
+            },
+            {
+              identicalUnits: 6,
+              type: "HMO",
+              area: 66,
+              habitable: 4,
+              bedrooms: 3,
+              tenure: "DMR",
+              provider: "affordableHousing",
+              compliance: ["m432b", "m432a"],
+              garden: "false",
+              sheltered: "true",
+              olderPersons: "false",
+            },
+          ],
+          "mockData.one.identicalUnits": 3,
+          "mockData.one.type": "flat",
+          "mockData.one.area": 3,
+          "mockData.one.habitable": 6,
+          "mockData.one.bedrooms": 3,
+          "mockData.one.tenure": "DMS",
+          "mockData.one.provider": "private",
+          "mockData.one.compliance": ["m42", "m432a", "m432b"],
+          "mockData.one.garden": "false",
+          "mockData.one.sheltered": "true",
+          "mockData.one.olderPersons": "true",
+          "mockData.two.identicalUnits": 6,
+          "mockData.two.type": "HMO",
+          "mockData.two.area": 66,
+          "mockData.two.habitable": 4,
+          "mockData.two.bedrooms": 3,
+          "mockData.two.tenure": "DMR",
+          "mockData.two.provider": "affordableHousing",
+          "mockData.two.compliance": ["m432b", "m432a"],
+          "mockData.two.garden": "false",
+          "mockData.two.sheltered": "true",
+          "mockData.two.olderPersons": "false",
+          "mockData.total.listItems": 2,
+          "mockData.total.units": 9,
+        },
+      },
+    };
+
+    const expected = {
+      proposalDetails: [
+        {
+          question:
+            "[Residential units (GLA) - Gained] Number of units of this type (Gained residential unit type 1)",
+          responses: [
+            {
+              value: "3",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question:
+            "[Residential units (GLA) - Gained] What best describes this unit? (Gained residential unit type 1)",
+          responses: [
+            {
+              value: "flat",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question:
+            "[Residential units (GLA) - Gained] What will be the Gross Internal Floor Area (GIA) of this unit? (Gained residential unit type 1)",
+          responses: [
+            {
+              value: "3",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question:
+            "[Residential units (GLA) - Gained] How many habitable rooms will this unit have? (Gained residential unit type 1)",
+          responses: [
+            {
+              value: "6",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question:
+            "[Residential units (GLA) - Gained] How many bedrooms will this unit have? (Gained residential unit type 1)",
+          responses: [
+            {
+              value: "3",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question:
+            "[Residential units (GLA) - Gained] What best describes the tenure of this unit? (Gained residential unit type 1)",
+          responses: [
+            {
+              value: "DMS",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question:
+            "[Residential units (GLA) - Gained] What best describes the provider of this unit? (Gained residential unit type 1)",
+          responses: [
+            {
+              value: "private",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question:
+            "[Residential units (GLA) - Gained] Will this unit be compliant with any of the following? (Gained residential unit type 1)",
+          responses: [
+            {
+              value: "m42",
+            },
+            {
+              value: "m432a",
+            },
+            {
+              value: "m432b",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question:
+            "[Residential units (GLA) - Gained] Will this unit be built on garden land? (Gained residential unit type 1)",
+          responses: [
+            {
+              value: "false",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question:
+            "[Residential units (GLA) - Gained] Will this unit provide sheltered accommodation? (Gained residential unit type 1)",
+          responses: [
+            {
+              value: "true",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question:
+            "[Residential units (GLA) - Gained] Is this unit specifically designed for older people? (Gained residential unit type 1)",
+          responses: [
+            {
+              value: "true",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question:
+            "[Residential units (GLA) - Gained] Number of units of this type (Gained residential unit type 2)",
+          responses: [
+            {
+              value: "6",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question:
+            "[Residential units (GLA) - Gained] What best describes this unit? (Gained residential unit type 2)",
+          responses: [
+            {
+              value: "HMO",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question:
+            "[Residential units (GLA) - Gained] What will be the Gross Internal Floor Area (GIA) of this unit? (Gained residential unit type 2)",
+          responses: [
+            {
+              value: "66",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question:
+            "[Residential units (GLA) - Gained] How many habitable rooms will this unit have? (Gained residential unit type 2)",
+          responses: [
+            {
+              value: "4",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question:
+            "[Residential units (GLA) - Gained] How many bedrooms will this unit have? (Gained residential unit type 2)",
+          responses: [
+            {
+              value: "3",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question:
+            "[Residential units (GLA) - Gained] What best describes the tenure of this unit? (Gained residential unit type 2)",
+          responses: [
+            {
+              value: "DMR",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question:
+            "[Residential units (GLA) - Gained] What best describes the provider of this unit? (Gained residential unit type 2)",
+          responses: [
+            {
+              value: "affordableHousing",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question:
+            "[Residential units (GLA) - Gained] Will this unit be compliant with any of the following? (Gained residential unit type 2)",
+          responses: [
+            {
+              value: "m432b",
+            },
+            {
+              value: "m432a",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question:
+            "[Residential units (GLA) - Gained] Will this unit be built on garden land? (Gained residential unit type 2)",
+          responses: [
+            {
+              value: "false",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question:
+            "[Residential units (GLA) - Gained] Will this unit provide sheltered accommodation? (Gained residential unit type 2)",
+          responses: [
+            {
+              value: "true",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question:
+            "[Residential units (GLA) - Gained] Is this unit specifically designed for older people? (Gained residential unit type 2)",
+          responses: [
+            {
+              value: "false",
+            },
+          ],
+          metadata: {},
+        },
+      ],
+      feedback: undefined,
+    };
+
+    const actual = formatProposalDetails({
+      flow: mockFlow,
+      breadcrumbs: mockBreadcrumbs,
+    });
+
+    // Tested behaviour -
+    // - Response values are correct
+    // - Multiple responses are handled
+    // - Response values are cast to strings
+    // - Component title is prepended to questions
+    // - Item number and schema type is appended to questions
+    expect(actual).toStrictEqual(expected);
+  });
+
+  test("List component, with map fields", () => {
+    const mockFlow: FlowGraph = {
+      _root: {
+        edges: ["7RJ1NQttcX", "oOD6xqekEk"],
+      },
+      "7RJ1NQttcX": {
+        data: {
+          title: "Find the property",
+          newAddressTitle:
+            "Click or tap at where the property is on the map and name it below",
+          allowNewAddresses: false,
+          newAddressDescription:
+            "You will need to select a location and provide a name to continue",
+          newAddressDescriptionLabel: "Name the site",
+        },
+        type: 9,
+      },
+      oOD6xqekEk: {
+        data: {
+          fn: "mockData",
+          tags: [],
+          title: "Trees",
+          schema: {
+            min: 1,
+            type: "Tree type",
+            fields: [
+              {
+                data: {
+                  fn: "species",
+                  type: "short",
+                  title: "Species",
+                },
+                type: "text",
+              },
+              {
+                data: {
+                  fn: "work",
+                  type: "short",
+                  title: "Proposed work",
+                },
+                type: "text",
+              },
+              {
+                data: {
+                  fn: "justification",
+                  type: "short",
+                  title: "Justification",
+                },
+                type: "text",
+              },
+              {
+                data: {
+                  fn: "urgency",
+                  title: "Urgency",
+                  options: [
+                    {
+                      id: "low",
+                      data: {
+                        val: "low",
+                        text: "Low",
+                      },
+                    },
+                    {
+                      id: "moderate",
+                      data: {
+                        val: "moderate",
+                        text: "Moderate",
+                      },
+                    },
+                    {
+                      id: "high",
+                      data: {
+                        val: "high",
+                        text: "High",
+                      },
+                    },
+                    {
+                      id: "urgent",
+                      data: {
+                        val: "urgent",
+                        text: "Urgent",
+                      },
+                    },
+                  ],
+                },
+                type: "question",
+              },
+              {
+                data: {
+                  fn: "completionDate",
+                  title: "Expected completion date",
+                  description: "For example, 16 04 2027",
+                },
+                type: "date",
+              },
+              {
+                data: {
+                  fn: "features",
+                  title: "Where is it? Plot as many as apply",
+                  mapOptions: {
+                    basemap: "MapboxSatellite",
+                    drawMany: true,
+                    drawType: "Point",
+                    drawColor: "#66ff00",
+                  },
+                },
+                type: "map",
+              },
+            ],
+          },
+          schemaName: "Trees",
+        },
+        type: 800,
+      },
+    };
+
+    const mockBreadcrumbs: Breadcrumbs = {
+      "7RJ1NQttcX": {
+        auto: false,
+        data: {
+          _address: {
+            uprn: "100021853107",
+            usrn: "21900730",
+            blpu_code: "2",
+            latitude: 51.4500211,
+            longitude: -0.140395,
+            organisation: null,
+            sao: "",
+            saoEnd: "",
+            pao: "1",
+            paoEnd: "",
+            street: "HONEYBROOK ROAD",
+            town: "LONDON",
+            postcode: "SW12 0DP",
+            ward: "E05014101",
+            x: 529315,
+            y: 173977,
+            planx_description: "Residential - Terraced",
+            planx_value: "residential.dwelling.house.terrace",
+            single_line_address:
+              "1, HONEYBROOK ROAD, LONDON, LAMBETH, SW12 0DP",
+            title: "1, HONEYBROOK ROAD, LONDON",
+            source: "os",
+          },
+          "property.type": ["residential.dwelling.house.terrace"],
+          "property.localAuthorityDistrict": ["Lambeth"],
+          "property.region": ["London"],
+          "property.boundary.title": {
+            geometry: {
+              type: "MultiPolygon",
+              coordinates: [
+                [
+                  [
+                    [-0.140286, 51.449978],
+                    [-0.14025, 51.450032],
+                    [-0.140342, 51.450057],
+                    [-0.14041, 51.450075],
+                    [-0.140496, 51.450099],
+                    [-0.140572, 51.450119],
+                    [-0.140609, 51.450063],
+                    [-0.140286, 51.449978],
+                  ],
+                ],
+              ],
+            },
+            type: "Feature",
+            properties: {
+              "entry-date": "2024-05-06",
+              "start-date": "2002-11-30",
+              "end-date": "",
+              entity: 12000560093,
+              name: "",
+              dataset: "title-boundary",
+              typology: "geography",
+              reference: "36780349",
+              prefix: "title-boundary",
+              "organisation-entity": "13",
+            },
+          },
+          "property.boundary.title.area": 161.15,
+          "property.boundary.title.area.hectares": 0.016115,
+          "findProperty.action": "Selected an existing address",
+        },
+      },
+      oOD6xqekEk: {
+        auto: false,
+        data: {
+          mockData: [
+            {
+              species: "Oak",
+              work: "Cut",
+              justification: "Required",
+              urgency: "low",
+              completionDate: "2025-11-11",
+              features: [
+                {
+                  type: "Feature",
+                  geometry: {
+                    type: "Point",
+                    coordinates: [-0.14031096108073457, 51.449894101629866],
+                  },
+                  properties: {
+                    label: "1",
+                  },
+                },
+                {
+                  type: "Feature",
+                  geometry: {
+                    type: "Point",
+                    coordinates: [-0.14025483261082808, 51.44997710172876],
+                  },
+                  properties: {
+                    label: "2",
+                  },
+                },
+                {
+                  type: "Feature",
+                  geometry: {
+                    type: "Point",
+                    coordinates: [-0.14020244080366107, 51.45006701119439],
+                  },
+                  properties: {
+                    label: "3",
+                  },
+                },
+                {
+                  type: "Feature",
+                  geometry: {
+                    type: "Point",
+                    coordinates: [-0.14045793430046527, 51.45012560745087],
+                  },
+                  properties: {
+                    label: "4",
+                  },
+                },
+              ],
+            },
+            {
+              species: "Birch",
+              work: "Cut",
+              justification: "Required",
+              urgency: "low",
+              completionDate: "2025-12-12",
+              features: [
+                {
+                  type: "Feature",
+                  geometry: {
+                    type: "Point",
+                    coordinates: [-0.14049761752787732, 51.45015232366427],
+                  },
+                  properties: {
+                    label: "1",
+                  },
+                },
+                {
+                  type: "Feature",
+                  geometry: {
+                    type: "Point",
+                    coordinates: [-0.14044236596306203, 51.45015083081978],
+                  },
+                  properties: {
+                    label: "2",
+                  },
+                },
+                {
+                  type: "Feature",
+                  geometry: {
+                    type: "Point",
+                    coordinates: [-0.14044323632408542, 51.45009793677917],
+                  },
+                  properties: {
+                    label: "3",
+                  },
+                },
+                {
+                  type: "Feature",
+                  geometry: {
+                    type: "Point",
+                    coordinates: [-0.14036174304721172, 51.45013673852853],
+                  },
+                  properties: {
+                    label: "4",
+                  },
+                },
+              ],
+            },
+          ],
+          "mockData.one.species": "Oak",
+          "mockData.one.work": "Cut",
+          "mockData.one.justification": "Required",
+          "mockData.one.urgency": "low",
+          "mockData.one.completionDate": "2025-11-11",
+          "mockData.one.features": [
+            {
+              type: "Feature",
+              geometry: {
+                type: "Point",
+                coordinates: [-0.14031096108073457, 51.449894101629866],
+              },
+              properties: {
+                label: "1",
+              },
+            },
+            {
+              type: "Feature",
+              geometry: {
+                type: "Point",
+                coordinates: [-0.14025483261082808, 51.44997710172876],
+              },
+              properties: {
+                label: "2",
+              },
+            },
+            {
+              type: "Feature",
+              geometry: {
+                type: "Point",
+                coordinates: [-0.14020244080366107, 51.45006701119439],
+              },
+              properties: {
+                label: "3",
+              },
+            },
+            {
+              type: "Feature",
+              geometry: {
+                type: "Point",
+                coordinates: [-0.14045793430046527, 51.45012560745087],
+              },
+              properties: {
+                label: "4",
+              },
+            },
+          ],
+          "mockData.two.species": "Birch",
+          "mockData.two.work": "Cut",
+          "mockData.two.justification": "Required",
+          "mockData.two.urgency": "low",
+          "mockData.two.completionDate": "2025-12-12",
+          "mockData.two.features": [
+            {
+              type: "Feature",
+              geometry: {
+                type: "Point",
+                coordinates: [-0.14049761752787732, 51.45015232366427],
+              },
+              properties: {
+                label: "1",
+              },
+            },
+            {
+              type: "Feature",
+              geometry: {
+                type: "Point",
+                coordinates: [-0.14044236596306203, 51.45015083081978],
+              },
+              properties: {
+                label: "2",
+              },
+            },
+            {
+              type: "Feature",
+              geometry: {
+                type: "Point",
+                coordinates: [-0.14044323632408542, 51.45009793677917],
+              },
+              properties: {
+                label: "3",
+              },
+            },
+            {
+              type: "Feature",
+              geometry: {
+                type: "Point",
+                coordinates: [-0.14036174304721172, 51.45013673852853],
+              },
+              properties: {
+                label: "4",
+              },
+            },
+          ],
+          "mockData.total.listItems": 2,
+        },
+      },
+    };
+
+    const expected = {
+      proposalDetails: [
+        {
+          question: "[Trees] Species (Tree type 1)",
+          responses: [
+            {
+              value: "Oak",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question: "[Trees] Proposed work (Tree type 1)",
+          responses: [
+            {
+              value: "Cut",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question: "[Trees] Justification (Tree type 1)",
+          responses: [
+            {
+              value: "Required",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question: "[Trees] Urgency (Tree type 1)",
+          responses: [
+            {
+              value: "low",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question: "[Trees] Expected completion date (Tree type 1)",
+          responses: [
+            {
+              value: "2025-11-11",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question: "[Trees] Where is it? Plot as many as apply (Tree type 1)",
+          responses: [
+            {
+              value:
+                '{"type":"Feature","geometry":{"type":"Point","coordinates":[-0.14031096108073457,51.449894101629866]},"properties":{"label":"1"}}',
+            },
+            {
+              value:
+                '{"type":"Feature","geometry":{"type":"Point","coordinates":[-0.14025483261082808,51.44997710172876]},"properties":{"label":"2"}}',
+            },
+            {
+              value:
+                '{"type":"Feature","geometry":{"type":"Point","coordinates":[-0.14020244080366107,51.45006701119439]},"properties":{"label":"3"}}',
+            },
+            {
+              value:
+                '{"type":"Feature","geometry":{"type":"Point","coordinates":[-0.14045793430046527,51.45012560745087]},"properties":{"label":"4"}}',
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question: "[Trees] Species (Tree type 2)",
+          responses: [
+            {
+              value: "Birch",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question: "[Trees] Proposed work (Tree type 2)",
+          responses: [
+            {
+              value: "Cut",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question: "[Trees] Justification (Tree type 2)",
+          responses: [
+            {
+              value: "Required",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question: "[Trees] Urgency (Tree type 2)",
+          responses: [
+            {
+              value: "low",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question: "[Trees] Expected completion date (Tree type 2)",
+          responses: [
+            {
+              value: "2025-12-12",
+            },
+          ],
+          metadata: {},
+        },
+        {
+          question: "[Trees] Where is it? Plot as many as apply (Tree type 2)",
+          responses: [
+            {
+              value:
+                '{"type":"Feature","geometry":{"type":"Point","coordinates":[-0.14049761752787732,51.45015232366427]},"properties":{"label":"1"}}',
+            },
+            {
+              value:
+                '{"type":"Feature","geometry":{"type":"Point","coordinates":[-0.14044236596306203,51.45015083081978]},"properties":{"label":"2"}}',
+            },
+            {
+              value:
+                '{"type":"Feature","geometry":{"type":"Point","coordinates":[-0.14044323632408542,51.45009793677917]},"properties":{"label":"3"}}',
+            },
+            {
+              value:
+                '{"type":"Feature","geometry":{"type":"Point","coordinates":[-0.14036174304721172,51.45013673852853]},"properties":{"label":"4"}}',
+            },
+          ],
+          metadata: {},
+        },
+      ],
+      feedback: undefined,
+    };
+
+    const actual = formatProposalDetails({
+      flow: mockFlow,
+      breadcrumbs: mockBreadcrumbs,
+    });
+
+    // Tested behaviour -
+    // - MapField responses are serialised to strings
+    expect(actual).toStrictEqual(expected);
   });
 });

--- a/src/export/bops/tests/proposalDetails.test.ts
+++ b/src/export/bops/tests/proposalDetails.test.ts
@@ -512,11 +512,16 @@ describe("Components which use an internal schema", () => {
       breadcrumbs: mockBreadcrumbs,
     });
 
-    // Tested behaviour -
-    // - Response values are correct
-    // - Response values are cast to strings
-    // - Component title is prepended to questions
+    // Formatted as expected
     expect(actual).toStrictEqual(expected);
+
+    // Responses are cast to strings
+    expect(actual.proposalDetails[0].responses[0]).toHaveProperty("value", "1");
+
+    // Component title is prepended to questions
+    expect(actual.proposalDetails[0].question).toMatch(
+      /[This is a page component]/,
+    );
   });
 
   test("List component", () => {
@@ -1251,13 +1256,17 @@ describe("Components which use an internal schema", () => {
       breadcrumbs: mockBreadcrumbs,
     });
 
-    // Tested behaviour -
-    // - Response values are correct
-    // - Multiple responses are handled
-    // - Response values are cast to strings
-    // - Component title is prepended to questions
-    // - Item number and schema type is appended to questions
+    // Formatted as expected
     expect(actual).toStrictEqual(expected);
+
+    // Multiple responses are handled
+    // This response is for a ChecklistField
+    expect(actual.proposalDetails[7].responses).toHaveLength(3);
+
+    // Item number and schema type are appended to questions
+    expect(actual.proposalDetails[0].question).toMatch(
+      /(Gained residential unit type 1)/,
+    );
   });
 
   test("List component, with map fields", () => {
@@ -1791,8 +1800,13 @@ describe("Components which use an internal schema", () => {
       breadcrumbs: mockBreadcrumbs,
     });
 
-    // Tested behaviour -
-    // - MapField responses are serialised to strings
+    // Formatted as expected
     expect(actual).toStrictEqual(expected);
+
+    // MapField responses are serialised to strings
+    expect(actual.proposalDetails[5].responses[0]).toHaveProperty(
+      "value",
+      expect.stringContaining('"type":"Feature"'),
+    );
   });
 });

--- a/src/export/bops/tests/proposalDetails.test.ts
+++ b/src/export/bops/tests/proposalDetails.test.ts
@@ -482,26 +482,23 @@ describe("Components which use an internal schema", () => {
       proposalDetails: [
         {
           metadata: {},
-          question:
-            "[This is a page component] How many fascia signs are you applying for?",
+          question: "How many fascia signs are you applying for?",
           responses: [{ value: "1" }],
         },
         {
           metadata: {},
           question:
-            "[This is a page component] How many projecting or hanging signs are you applying for?",
+            "How many projecting or hanging signs are you applying for?",
           responses: [{ value: "2" }],
         },
         {
           metadata: {},
-          question:
-            "[This is a page component] How many hoardings are you applying for?",
+          question: "How many hoardings are you applying for?",
           responses: [{ value: "3" }],
         },
         {
           metadata: {},
-          question:
-            "[This is a page component] How many other advertisements are you applying for?",
+          question: "How many other advertisements are you applying for?",
           responses: [{ value: "4" }],
         },
       ],
@@ -517,11 +514,6 @@ describe("Components which use an internal schema", () => {
 
     // Responses are cast to strings
     expect(actual.proposalDetails[0].responses[0]).toHaveProperty("value", "1");
-
-    // Component title is prepended to questions
-    expect(actual.proposalDetails[0].question).toMatch(
-      /[This is a page component]/,
-    );
   });
 
   test("List component", () => {
@@ -1020,7 +1012,7 @@ describe("Components which use an internal schema", () => {
       proposalDetails: [
         {
           question:
-            "[Residential units (GLA) - Gained] Number of units of this type (Gained residential unit type 1)",
+            "[Gained residential unit type 1] Number of units of this type",
           responses: [
             {
               value: "3",
@@ -1030,7 +1022,7 @@ describe("Components which use an internal schema", () => {
         },
         {
           question:
-            "[Residential units (GLA) - Gained] What best describes this unit? (Gained residential unit type 1)",
+            "[Gained residential unit type 1] What best describes this unit?",
           responses: [
             {
               value: "flat",
@@ -1040,7 +1032,7 @@ describe("Components which use an internal schema", () => {
         },
         {
           question:
-            "[Residential units (GLA) - Gained] What will be the Gross Internal Floor Area (GIA) of this unit? (Gained residential unit type 1)",
+            "[Gained residential unit type 1] What will be the Gross Internal Floor Area (GIA) of this unit?",
           responses: [
             {
               value: "3",
@@ -1050,7 +1042,7 @@ describe("Components which use an internal schema", () => {
         },
         {
           question:
-            "[Residential units (GLA) - Gained] How many habitable rooms will this unit have? (Gained residential unit type 1)",
+            "[Gained residential unit type 1] How many habitable rooms will this unit have?",
           responses: [
             {
               value: "6",
@@ -1060,7 +1052,7 @@ describe("Components which use an internal schema", () => {
         },
         {
           question:
-            "[Residential units (GLA) - Gained] How many bedrooms will this unit have? (Gained residential unit type 1)",
+            "[Gained residential unit type 1] How many bedrooms will this unit have?",
           responses: [
             {
               value: "3",
@@ -1070,7 +1062,7 @@ describe("Components which use an internal schema", () => {
         },
         {
           question:
-            "[Residential units (GLA) - Gained] What best describes the tenure of this unit? (Gained residential unit type 1)",
+            "[Gained residential unit type 1] What best describes the tenure of this unit?",
           responses: [
             {
               value: "DMS",
@@ -1080,7 +1072,7 @@ describe("Components which use an internal schema", () => {
         },
         {
           question:
-            "[Residential units (GLA) - Gained] What best describes the provider of this unit? (Gained residential unit type 1)",
+            "[Gained residential unit type 1] What best describes the provider of this unit?",
           responses: [
             {
               value: "private",
@@ -1090,7 +1082,7 @@ describe("Components which use an internal schema", () => {
         },
         {
           question:
-            "[Residential units (GLA) - Gained] Will this unit be compliant with any of the following? (Gained residential unit type 1)",
+            "[Gained residential unit type 1] Will this unit be compliant with any of the following?",
           responses: [
             {
               value: "m42",
@@ -1106,7 +1098,7 @@ describe("Components which use an internal schema", () => {
         },
         {
           question:
-            "[Residential units (GLA) - Gained] Will this unit be built on garden land? (Gained residential unit type 1)",
+            "[Gained residential unit type 1] Will this unit be built on garden land?",
           responses: [
             {
               value: "false",
@@ -1116,7 +1108,7 @@ describe("Components which use an internal schema", () => {
         },
         {
           question:
-            "[Residential units (GLA) - Gained] Will this unit provide sheltered accommodation? (Gained residential unit type 1)",
+            "[Gained residential unit type 1] Will this unit provide sheltered accommodation?",
           responses: [
             {
               value: "true",
@@ -1126,7 +1118,7 @@ describe("Components which use an internal schema", () => {
         },
         {
           question:
-            "[Residential units (GLA) - Gained] Is this unit specifically designed for older people? (Gained residential unit type 1)",
+            "[Gained residential unit type 1] Is this unit specifically designed for older people?",
           responses: [
             {
               value: "true",
@@ -1136,7 +1128,7 @@ describe("Components which use an internal schema", () => {
         },
         {
           question:
-            "[Residential units (GLA) - Gained] Number of units of this type (Gained residential unit type 2)",
+            "[Gained residential unit type 2] Number of units of this type",
           responses: [
             {
               value: "6",
@@ -1146,7 +1138,7 @@ describe("Components which use an internal schema", () => {
         },
         {
           question:
-            "[Residential units (GLA) - Gained] What best describes this unit? (Gained residential unit type 2)",
+            "[Gained residential unit type 2] What best describes this unit?",
           responses: [
             {
               value: "HMO",
@@ -1156,7 +1148,7 @@ describe("Components which use an internal schema", () => {
         },
         {
           question:
-            "[Residential units (GLA) - Gained] What will be the Gross Internal Floor Area (GIA) of this unit? (Gained residential unit type 2)",
+            "[Gained residential unit type 2] What will be the Gross Internal Floor Area (GIA) of this unit?",
           responses: [
             {
               value: "66",
@@ -1166,7 +1158,7 @@ describe("Components which use an internal schema", () => {
         },
         {
           question:
-            "[Residential units (GLA) - Gained] How many habitable rooms will this unit have? (Gained residential unit type 2)",
+            "[Gained residential unit type 2] How many habitable rooms will this unit have?",
           responses: [
             {
               value: "4",
@@ -1176,7 +1168,7 @@ describe("Components which use an internal schema", () => {
         },
         {
           question:
-            "[Residential units (GLA) - Gained] How many bedrooms will this unit have? (Gained residential unit type 2)",
+            "[Gained residential unit type 2] How many bedrooms will this unit have?",
           responses: [
             {
               value: "3",
@@ -1186,7 +1178,7 @@ describe("Components which use an internal schema", () => {
         },
         {
           question:
-            "[Residential units (GLA) - Gained] What best describes the tenure of this unit? (Gained residential unit type 2)",
+            "[Gained residential unit type 2] What best describes the tenure of this unit?",
           responses: [
             {
               value: "DMR",
@@ -1196,7 +1188,7 @@ describe("Components which use an internal schema", () => {
         },
         {
           question:
-            "[Residential units (GLA) - Gained] What best describes the provider of this unit? (Gained residential unit type 2)",
+            "[Gained residential unit type 2] What best describes the provider of this unit?",
           responses: [
             {
               value: "affordableHousing",
@@ -1206,7 +1198,7 @@ describe("Components which use an internal schema", () => {
         },
         {
           question:
-            "[Residential units (GLA) - Gained] Will this unit be compliant with any of the following? (Gained residential unit type 2)",
+            "[Gained residential unit type 2] Will this unit be compliant with any of the following?",
           responses: [
             {
               value: "m432b",
@@ -1219,7 +1211,7 @@ describe("Components which use an internal schema", () => {
         },
         {
           question:
-            "[Residential units (GLA) - Gained] Will this unit be built on garden land? (Gained residential unit type 2)",
+            "[Gained residential unit type 2] Will this unit be built on garden land?",
           responses: [
             {
               value: "false",
@@ -1229,7 +1221,7 @@ describe("Components which use an internal schema", () => {
         },
         {
           question:
-            "[Residential units (GLA) - Gained] Will this unit provide sheltered accommodation? (Gained residential unit type 2)",
+            "[Gained residential unit type 2] Will this unit provide sheltered accommodation?",
           responses: [
             {
               value: "true",
@@ -1239,7 +1231,7 @@ describe("Components which use an internal schema", () => {
         },
         {
           question:
-            "[Residential units (GLA) - Gained] Is this unit specifically designed for older people? (Gained residential unit type 2)",
+            "[Gained residential unit type 2] Is this unit specifically designed for older people?",
           responses: [
             {
               value: "false",
@@ -1263,9 +1255,9 @@ describe("Components which use an internal schema", () => {
     // This response is for a ChecklistField
     expect(actual.proposalDetails[7].responses).toHaveLength(3);
 
-    // Item number and schema type are appended to questions
+    // Item number and schema type are prepended to questions
     expect(actual.proposalDetails[0].question).toMatch(
-      /(Gained residential unit type 1)/,
+      /[Gained residential unit type 1]/,
     );
   });
 
@@ -1658,7 +1650,7 @@ describe("Components which use an internal schema", () => {
     const expected = {
       proposalDetails: [
         {
-          question: "[Trees] Species (Tree type 1)",
+          question: "[Tree type 1] Species",
           responses: [
             {
               value: "Oak",
@@ -1667,7 +1659,7 @@ describe("Components which use an internal schema", () => {
           metadata: {},
         },
         {
-          question: "[Trees] Proposed work (Tree type 1)",
+          question: "[Tree type 1] Proposed work",
           responses: [
             {
               value: "Cut",
@@ -1676,7 +1668,7 @@ describe("Components which use an internal schema", () => {
           metadata: {},
         },
         {
-          question: "[Trees] Justification (Tree type 1)",
+          question: "[Tree type 1] Justification",
           responses: [
             {
               value: "Required",
@@ -1685,7 +1677,7 @@ describe("Components which use an internal schema", () => {
           metadata: {},
         },
         {
-          question: "[Trees] Urgency (Tree type 1)",
+          question: "[Tree type 1] Urgency",
           responses: [
             {
               value: "low",
@@ -1694,7 +1686,7 @@ describe("Components which use an internal schema", () => {
           metadata: {},
         },
         {
-          question: "[Trees] Expected completion date (Tree type 1)",
+          question: "[Tree type 1] Expected completion date",
           responses: [
             {
               value: "2025-11-11",
@@ -1703,7 +1695,7 @@ describe("Components which use an internal schema", () => {
           metadata: {},
         },
         {
-          question: "[Trees] Where is it? Plot as many as apply (Tree type 1)",
+          question: "[Tree type 1] Where is it? Plot as many as apply",
           responses: [
             {
               value:
@@ -1725,7 +1717,7 @@ describe("Components which use an internal schema", () => {
           metadata: {},
         },
         {
-          question: "[Trees] Species (Tree type 2)",
+          question: "[Tree type 2] Species",
           responses: [
             {
               value: "Birch",
@@ -1734,7 +1726,7 @@ describe("Components which use an internal schema", () => {
           metadata: {},
         },
         {
-          question: "[Trees] Proposed work (Tree type 2)",
+          question: "[Tree type 2] Proposed work",
           responses: [
             {
               value: "Cut",
@@ -1743,7 +1735,7 @@ describe("Components which use an internal schema", () => {
           metadata: {},
         },
         {
-          question: "[Trees] Justification (Tree type 2)",
+          question: "[Tree type 2] Justification",
           responses: [
             {
               value: "Required",
@@ -1752,7 +1744,7 @@ describe("Components which use an internal schema", () => {
           metadata: {},
         },
         {
-          question: "[Trees] Urgency (Tree type 2)",
+          question: "[Tree type 2] Urgency",
           responses: [
             {
               value: "low",
@@ -1761,7 +1753,7 @@ describe("Components which use an internal schema", () => {
           metadata: {},
         },
         {
-          question: "[Trees] Expected completion date (Tree type 2)",
+          question: "[Tree type 2] Expected completion date",
           responses: [
             {
               value: "2025-12-12",
@@ -1770,7 +1762,7 @@ describe("Components which use an internal schema", () => {
           metadata: {},
         },
         {
-          question: "[Trees] Where is it? Plot as many as apply (Tree type 2)",
+          question: "[Tree type 2] Where is it? Plot as many as apply",
           responses: [
             {
               value:


### PR DESCRIPTION
## What does this PR do?
 - Ensures that when a payload contains a `List` or `Page` component, that the values are parsed
 - These parsed values are used in the following ways - 
   - Responses in `DigitalPlanningPayload`
   - Responses in CSV
   - Responses in generated HTML docs

There's a lot of room for refactors and improvements in this area of the code base, but I've tried to make this an additive change here instead of starting to untangle too much at the same time.