### PR TITLE
fix: filter questions without responses out of generated docs (take 2)

### DIFF
--- a/src/export/bops/index.ts
+++ b/src/export/bops/index.ts
@@ -159,7 +159,7 @@ export function formatProposalDetails({
     );
     if (!isTypeForBopsPayload(crumb.type) || !validKey) continue;
 
-    const answers: Array<string> = (() => {
+    const answers: Array<string> | undefined = (() => {
       switch (crumb.type) {
         case ComponentType.AddressInput:
           try {
@@ -228,11 +228,12 @@ export function formatProposalDetails({
         case ComponentType.Checklist:
         case ComponentType.Question:
         default:
+          // Filter out "sticky note" questions without answers
           return crumb.answers;
       }
     })();
 
-    if (!answers) continue; // Quit loop if no answers for node
+    if (!answers) continue;
 
     const responses = answers.map((id) => {
       let value = id;

--- a/src/export/bops/index.ts
+++ b/src/export/bops/index.ts
@@ -228,9 +228,11 @@ export function formatProposalDetails({
         case ComponentType.Checklist:
         case ComponentType.Question:
         default:
-          return crumb.answers ?? [];
+          return crumb.answers;
       }
     })();
+
+    if (!answers) continue; // Quit loop if no answers for node
 
     const responses = answers.map((id) => {
       let value = id;

--- a/src/export/bops/tests/proposalDetails.test.ts
+++ b/src/export/bops/tests/proposalDetails.test.ts
@@ -14,6 +14,7 @@ const mockFlow = {
       "aKhcyyHYAG",
       "AFoFsXSPus",
       "fnT4PnVhhJ",
+      "8AOC7IRavY",
     ],
   },
   zQlvAHP8lw: {
@@ -129,6 +130,13 @@ const mockFlow = {
     },
     type: 120,
   },
+  "8AOC7IRavY": {
+    data: {
+      text: "This is a sticky note question",
+      neverAutoAnswer: false,
+    },
+    type: 100,
+  },
 };
 
 const mockBreadcrumbs = {
@@ -239,6 +247,64 @@ test("removed nodes are skipped", () => {
       data: {
         text: "Breadcrumb which no longer exists in the flow",
       },
+    },
+  };
+
+  const expected = {
+    feedback: {
+      find_property: "test",
+    },
+    proposalDetails: [
+      {
+        metadata: {},
+        question: "address question",
+        responses: [{ value: "line1, line, town, county, postcode" }],
+      },
+      {
+        metadata: {},
+        question: "checklist",
+        responses: [{ value: "1" }, { value: "2" }],
+      },
+      {
+        metadata: {},
+        question: "expandable checklist question",
+        responses: [{ value: "c1" }, { value: "c2" }, { value: "c3" }],
+      },
+      {
+        metadata: {},
+        question: "date question",
+        responses: [{ value: "1999-01-01" }],
+      },
+      {
+        metadata: {},
+        question: "number question",
+        responses: [{ value: "500" }],
+      },
+      {
+        metadata: {},
+        question: "regular question",
+        responses: [{ value: "a1" }],
+      },
+      {
+        metadata: {},
+        question: "text question",
+        responses: [{ value: "testanswer" }],
+      },
+    ],
+  };
+
+  const actual = formatProposalDetails({
+    flow: mockFlow,
+    breadcrumbs: mockBreadcrumbsWithAdditionalNode,
+  });
+  expect(actual).toStrictEqual(expected);
+});
+
+test("sticky note question nodes are omitted", () => {
+  const mockBreadcrumbsWithAdditionalNode = {
+    ...mockBreadcrumbs,
+    "8AOC7IRavY": {
+      auto: true,
     },
   };
 


### PR DESCRIPTION
Simpler solution to #554, implemented here https://github.com/theopensystemslab/planx-new/pull/3918

Per bug report here https://opensystemslab.slack.com/archives/C01E3AC0C03/p1730907777602279

Questions without `edges` (aka "sticky note" questions) now leave a breadcrumb per the new automation logic, whereas before they didn't. They were being correctly filtered out of the Result & Review pages in-service, but incorrectly included in the submission documents.