### PR TITLE
feat: Use `getFeeBreakdown()` util for generating payload

### DIFF
--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -16,6 +16,7 @@ import {
   SessionMetadata,
   Value,
 } from "../../types";
+import { getFeeBreakdown } from "../../utils";
 import {
   extractFileDescriptionForPassportKey,
   formatProposalDetails,
@@ -606,10 +607,11 @@ export class DigitalPlanning {
       };
     }
 
+    const feeBreakdown = getFeeBreakdown(this.passport.data);
+
     const baseFee = {
-      calculated:
-        (this.passport.data?.["application.fee.calculated"] as number) || 0,
-      payable: (this.passport.data?.["application.fee.payable"] as number) || 0,
+      calculated: feeBreakdown.amount.calculated,
+      payable: feeBreakdown.amount.payable,
       category: {
         one:
           (this.passport.data?.["application.fee.category.one"] as number) || 0,
@@ -666,23 +668,13 @@ export class DigitalPlanning {
           ] as number) || 0,
       },
       exemption: {
-        disability: this.stringToBool(
-          this.passport.data?.["application.fee.exemption.disability"]?.[0],
-        ),
-        resubmission: this.stringToBool(
-          this.passport.data?.["application.fee.exemption.resubmission"]?.[0],
-        ),
+        disability: feeBreakdown.exemptions.includes("disability"),
+        resubmission: feeBreakdown.exemptions.includes("resubmission"),
       },
       reduction: {
-        sports: this.stringToBool(
-          this.passport.data?.["application.fee.reduction.sports"]?.[0],
-        ),
-        parishCouncil: this.stringToBool(
-          this.passport.data?.["application.fee.reduction.parishCouncil"]?.[0],
-        ),
-        alternative: this.stringToBool(
-          this.passport.data?.["application.fee.reduction.alternative"]?.[0],
-        ),
+        sports: feeBreakdown.reductions.includes("sports"),
+        parishCouncil: feeBreakdown.reductions.includes("parishCouncil"),
+        alternative: feeBreakdown.reductions.includes("alternative"),
       },
     };
 


### PR DESCRIPTION
Small refactor to use a single passport mapping for fee breakdown - this should mean that we could add new values (e.g. exemptions, reductions) in a simpler manner in future.

A nice enhancement here would be to also grab the fee categories in `getFeeBreakdown()`