### PR TITLE
feat: Update check for pay component

### DIFF
--- a/src/export/digitalPlanning/mocks/flows/notificationOfCommencement.ts
+++ b/src/export/digitalPlanning/mocks/flows/notificationOfCommencement.ts
@@ -1,0 +1,133 @@
+import { FlowGraph } from "../../../../types/index.js";
+
+// Copied from Buckinghamshire on 08 Jan 2025
+export const mockPublishedNOCFlow: FlowGraph = {
+  _root: {
+    edges: [
+      "PckGxO4AgQ",
+      "CReH0ZUnB3",
+      "Z28tn2t9BM",
+      "XJtWHBn8KR",
+      "P4fRVlKmNI",
+      "8Mzv0b42Oi",
+      "4I52b5H8rL",
+      "asb0FVgtVm",
+      "s2YTmALWV0",
+      "4nnttggnfo",
+      "mFwLvDuxLF",
+    ],
+  },
+  "1AtpbUszBk": { data: { title: "When did the works start?" }, type: 120 },
+  "1zl0bfRMLa": {
+    data: { val: "Commencement", text: "Commencement" },
+    type: 200,
+  },
+  "3NhRaQKv45": {
+    data: { val: "Commencement", text: "Yes" },
+    type: 200,
+    edges: ["z0b63MQEEV", "1AtpbUszBk", "K1Z8oWKho2"],
+  },
+  "4I52b5H8rL": {
+    data: { type: "short", title: "Application Number" },
+    type: 110,
+  },
+  "4nnttggnfo": { data: { title: "Send", destinations: ["email"] }, type: 650 },
+  "8Mzv0b42Oi": {
+    data: { fn: "site.address", title: "Site Address Details" },
+    type: 130,
+  },
+  CReH0ZUnB3: {
+    data: {
+      color: "#EFEFEF",
+      title: "This is a new service",
+      description:
+        "<p>We&apos;re always working to improve this service. If you spot issues or have comments on how to make it better, you can leave feedback using the link to the bottom left of your browser window as you go along.</p><p>Please use the screenshot button for feedback. This will not capture any of your personal data but it helps us to see where you were in the service.</p>",
+      resetButton: false,
+    },
+    type: 8,
+  },
+  K1Z8oWKho2: {
+    data: { text: "I confirm that:", allRequired: true },
+    type: 105,
+    edges: ["sG3PED8dKU"],
+  },
+  P4fRVlKmNI: { data: { fn: "contact", title: "Contact details" }, type: 135 },
+  PckGxO4AgQ: {
+    data: {
+      content:
+        "<h1>Notification of commencement</h1><p>You can use this free service to notify the commencement of works to a member of the Building Control team.</p><p>You can leave and return to this service using the same link at any time.</p>",
+    },
+    type: 250,
+  },
+  V9Nmizh8Tx: {
+    data: {
+      text: "I confirm that we intend to start the works on the stated date and will notify you no more than five working days after the work has satisfied the definition of the commencement of work.",
+    },
+    type: 200,
+  },
+  XJtWHBn8KR: {
+    data: {
+      color: "#EFEFEF",
+      title:
+        "You are required to notify Building Control twice of work starting:",
+      description:
+        "<p>1. A notification must be submitted to building control at least two working days before intention to start work.</p><p>2. A further notification must be submitted, no more than five working days after the work has satisfied the above definition of the commencement of work.</p>",
+      resetButton: false,
+    },
+    type: 8,
+  },
+  Z28tn2t9BM: {
+    data: {
+      color: "#EFEFEF",
+      title: "From 1st October 2023, the definition of a commencement is:",
+      description:
+        "<p>· Where the work is a new build or a horizontal extension of a building, work is to be regarded as commenced when the sub-surface structure of the building or the extension including all foundations, any basement level (if any) and the structure of ground floor level is completed.</p><p>· Where the work consists of any other building work, the work is to be regarded as commenced when 15% of the proposed work has been completed.</p>",
+      resetButton: false,
+    },
+    type: 8,
+  },
+  asb0FVgtVm: {
+    data: { fn: "works.started", text: "Have the works started?" },
+    type: 100,
+    edges: ["3NhRaQKv45", "qs1gXUH8ZN"],
+  },
+  b5pK0rrHKH: { data: { val: "Start", text: "Start" }, type: 200 },
+  lQJYfgKqZx: {
+    data: { text: "I confirm that:", allRequired: true },
+    type: 105,
+    edges: ["V9Nmizh8Tx"],
+  },
+  mFwLvDuxLF: {
+    data: {
+      heading: "Notification sent",
+      moreInfo:
+        "<h2>You will be contacted</h2><ul><li><p>if there is anything missing from the information you have provided so far</p></li><li><p>if any additional information is required</p></li></ul>",
+      contactInfo:
+        "You can contact us at <em>planning@lambeth.gov.uk</em>\n          <br/><br/>\n          What did you think of this service? Please give us your feedback using the link in the footer below.",
+      description:
+        "Thank you for your submission. You will also receive an email to confirm when your request has been received.",
+    },
+    type: 725,
+  },
+  qs1gXUH8ZN: {
+    data: { val: "Start", text: "No" },
+    type: 200,
+    edges: ["z0b63MQEEV", "tTvgNj1TTX", "lQJYfgKqZx"],
+  },
+  s2YTmALWV0: {
+    data: { title: "Check your answers before sending" },
+    type: 600,
+  },
+  sG3PED8dKU: {
+    data: {
+      text: "That the work has satisfied the definition of the commencement of work.",
+    },
+    type: 200,
+  },
+  tTvgNj1TTX: { data: { title: "When will the works start?" }, type: 120 },
+  z0b63MQEEV: {
+    data: { fn: "works.started", text: "What is the status?" },
+    type: 100,
+    edges: ["1zl0bfRMLa", "b5pK0rrHKH"],
+  },
+};

--- a/src/export/digitalPlanning/mocks/notificationOfCommencement.ts
+++ b/src/export/digitalPlanning/mocks/notificationOfCommencement.ts
@@ -1,0 +1,128 @@
+export const mockNOCSession = {
+  id: "56750f3b-e94f-4163-817d-b7baa10cac67",
+  flow: {
+    slug: "notification-of-commencement",
+    team: {
+      slug: "buckinghamshire",
+      referenceCode: "BKM",
+    },
+  },
+  created_at: "2025-01-07T14:12:59.858297+00:00",
+  updated_at: "2025-01-08T03:00:08.433031+00:00",
+  submitted_at: "2025-01-07T14:16:40.761133+00:00",
+  locked_at: null,
+  sanitised_at: null,
+  email: "example@example.com",
+  passport: {
+    data: {
+      "1AtpbUszBk": "2024-05-01",
+      "4I52b5H8rL": "12/34567",
+      "site.address": {
+        town: "London",
+        line1: "40 Stansfield Road",
+        line2: "Brixton",
+        county: "Greater London",
+        country: "UK",
+        postcode: "SW9 9RZ",
+      },
+      "contact.email": "example@example.com",
+      "contact.title": "Mr",
+      "works.started": ["Commencement"],
+      "_contact.contact": {
+        contact: {
+          email: "example@example.com",
+          phone: "123456789",
+          title: "Mr",
+          lastName: "Bowie",
+          firstName: "David",
+          organisation: "",
+        },
+      },
+      emailSendEventId: "024bb906-1292-45b1-a6df-c1e87b668670",
+      "contact.name.last": "Bowie",
+      "contact.name.first": "David",
+      "contact.phone.primary": "123456789",
+    },
+  },
+  sessionId: "b04535f6-9752-42db-a249-269ebab0cf20",
+  breadcrumbs: {
+    "1AtpbUszBk": {
+      auto: false,
+      data: {
+        "1AtpbUszBk": "2024-05-01",
+      },
+    },
+    "4I52b5H8rL": {
+      auto: false,
+      data: {
+        "4I52b5H8rL": "24/01547",
+      },
+    },
+    "4nnttggnfo": {
+      auto: false,
+      data: {
+        emailSendEventId: "024aa906-1292-45a2-a6df-c1e87b121212",
+      },
+    },
+    "8Mzv0b42Oi": {
+      auto: false,
+      data: {
+        "site.address": {
+          town: "London",
+          line1: "40 Stansfield Road",
+          line2: "Brixton",
+          county: "Greater London",
+          country: "UK",
+          postcode: "SW9 9RZ",
+        },
+      },
+    },
+    CReH0ZUnB3: {
+      auto: false,
+    },
+    K1Z8oWKho2: {
+      auto: false,
+      answers: ["sG3PED8dKU"],
+    },
+    P4fRVlKmNI: {
+      auto: false,
+      data: {
+        "contact.email": "example@example.com",
+        "contact.title": "Mr",
+        "_contact.contact": {
+          contact: {
+            email: "example@example.com",
+            phone: "123456789",
+            title: "Mr",
+            lastName: "Bowie",
+            firstName: "David",
+            organisation: "",
+          },
+        },
+        "contact.name.last": "Bowie",
+        "contact.name.first": "David",
+        "contact.phone.primary": "123456789",
+      },
+    },
+    PckGxO4AgQ: {
+      auto: false,
+    },
+    XJtWHBn8KR: {
+      auto: false,
+    },
+    Z28tn2t9BM: {
+      auto: false,
+    },
+    asb0FVgtVm: {
+      auto: false,
+      answers: ["3NhRaQKv45"],
+    },
+    s2YTmALWV0: {
+      auto: false,
+    },
+    z0b63MQEEV: {
+      auto: true,
+      answers: ["1zl0bfRMLa"],
+    },
+  },
+};

--- a/src/export/digitalPlanning/model.test.ts
+++ b/src/export/digitalPlanning/model.test.ts
@@ -5,6 +5,7 @@ import {
   SessionMetadata,
 } from "../../types/index.js";
 import { mockPublishedLDCFlow } from "../bops/mocks/flow.js";
+import { mockPublishedNOCFlow } from "./mocks/flows/notificationOfCommencement.js";
 import { mockPublishedPlanningPermissionFlow } from "./mocks/flows/planningPermission.js";
 import { mockPublishedPriorApprovalFlow } from "./mocks/flows/priorApproval.js";
 import {
@@ -12,6 +13,7 @@ import {
   mockLDCPSession,
   mockLDCPSession2,
 } from "./mocks/lawfulDevelopmentCertificate.js";
+import { mockNOCSession } from "./mocks/notificationOfCommencement.js";
 import { mockPlanningPermissionSession } from "./mocks/planningPermission.js";
 import { mockPriorApprovalSession } from "./mocks/priorApproval.js";
 import { DigitalPlanning } from "./model.js";
@@ -91,6 +93,21 @@ const mockSessions = [
     metadata: mockMetadataForSession(
       mockPlanningPermissionSession.flow.team.slug,
       mockPlanningPermissionSession.flow.team.referenceCode,
+    ),
+  },
+];
+
+const mockDiscretionarySessions = [
+  {
+    name: "notification-of-commencement",
+    passport: new Passport({
+      data: { ...mockNOCSession.passport },
+    }),
+    breadcrumbs: mockNOCSession.breadcrumbs as Breadcrumbs,
+    flow: mockPublishedNOCFlow,
+    metadata: mockMetadataForSession(
+      mockNOCSession.flow.team.slug,
+      mockNOCSession.flow.team.referenceCode,
     ),
   },
 ];
@@ -304,6 +321,25 @@ describe("DigitalPlanning", () => {
       expect(payload.metadata.service!).toHaveProperty("files");
       // @ts-ignore
       expect(payload.metadata.service!.files!).toEqual(defaultRequestedFiles);
+    });
+  });
+
+  describe("discresionary services - skipped validation", () => {
+    mockDiscretionarySessions.forEach((mock) => {
+      it(`should return payload (${mock.name})`, () => {
+        const instance = new DigitalPlanning({
+          sessionId: "c06eebb7-6201-4bc0-9fe7-ec5d7a1c0797",
+          passport: mock.passport,
+          breadcrumbs: mock.breadcrumbs,
+          flow: mock.flow,
+          metadata: mock.metadata,
+        });
+
+        const skipValidation = true;
+        const payload = instance.getPayload(skipValidation);
+
+        expect(payload).toEqual(instance.payload);
+      });
     });
   });
 });

--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -23,6 +23,7 @@ import {
   formatProposalDetails,
   parsePolicyRefs,
 } from "../bops/index.js";
+import { Node } from "./../../types/flow";
 import jsonSchema from "./schema/schema.json" with { type: "json" };
 import {
   Application as Payload,
@@ -600,7 +601,10 @@ export class DigitalPlanning {
   }
 
   private getApplicationFee(): Payload["data"]["application"]["fee"] {
-    if (this.passport.data?.["application.type"]?.[0] === "listed") {
+    const hasPayComponent = Object.values(this.flow).find(
+      (node: Node) => node?.type === ComponentType.Pay,
+    );
+    if (!hasPayComponent) {
       return {
         notApplicable: true,
       };
@@ -925,12 +929,14 @@ export class DigitalPlanning {
   }
 
   private getFeeExplanations(): FeeExplanation | FeeExplanationNotApplicable {
-    if (this.passport.data?.["application.type"]?.[0] === "listed") {
+    const hasPayComponent = Object.values(this.flow).find(
+      (node: Node) => node?.type === ComponentType.Pay,
+    );
+    if (!hasPayComponent) {
       return {
         notApplicable: true,
       };
     }
-
     const explanations: FeeExplanation = {
       calculated: [],
       payable: [],

--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -23,7 +23,6 @@ import {
   formatProposalDetails,
   parsePolicyRefs,
 } from "../bops/index.js";
-import { Node } from "./../../types/flow";
 import jsonSchema from "./schema/schema.json" with { type: "json" };
 import {
   Application as Payload,


### PR DESCRIPTION
## What does this PR do?
- Correctly maps flows without a pay component to `ApplicationFeeNotApplicable`
- Adds test case for discretionary services without a pay component