### PR TITLE
fix: maps should fallback to old data fields for legacy sessions

### DIFF
--- a/src/export/bops/index.ts
+++ b/src/export/bops/index.ts
@@ -382,8 +382,9 @@ export function computeBOPSParams({
     data.site = site;
   }
 
-  // 1b. property boundary
-  const geojson = passport.any(["proposal.site"]);
+  // 1b. property boundary (sessions as of 8 Jan 25 use `proposal.site` while old ones use `property.boundary.site`)
+  const geojson =
+    passport.any(["proposal.site"]) || passport.any(["property.boundary.site"]);
   if (geojson) data.boundary_geojson = geojson;
 
   // 2. files

--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -467,12 +467,14 @@ export class DigitalPlanning {
     return {
       site: annotatedBoundary as GeoJSON,
       area: {
-        // Sessions as of 8 Jan 25 use `proposal.site.area` while old ones use `property.boundary.area`
+        // Sessions as of 8 Jan 25 use `proposal.site.area` while old ones use `property.boundary.area` or `proposal.siteArea`
         hectares:
           this.passport.data?.["proposal.site.area.hectares"] ||
+          this.passport.data?.["proposal.siteArea.hectares"] ||
           this.passport.data?.["proposal.boundary.area.hectares"],
         squareMetres:
           this.passport.data?.["proposal.site.area"] ||
+          this.passport.data?.["proposal.siteArea"] ||
           this.passport.data?.["property.boundary.area"],
       },
     } as Payload["data"]["proposal"]["boundary"];

--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -456,9 +456,10 @@ export class DigitalPlanning {
   }
 
   private getProposedBoundary(): Payload["data"]["proposal"]["boundary"] {
-    const annotatedBoundary = this.passport.data?.[
-      "proposal.site"
-    ] as unknown as Feature;
+    const annotatedBoundary =
+      // Sessions as of 8 Jan 25 use `proposal.site` while old ones use `property.boundary.site`
+      (this.passport.data?.["proposal.site"] as unknown as Feature) ||
+      (this.passport.data?.["property.boundary.site"] as unknown as Feature);
     if (annotatedBoundary && annotatedBoundary.properties)
       annotatedBoundary["properties"]["planx_user_action"] =
         this.passport.data?.["drawBoundary.action"];
@@ -466,12 +467,13 @@ export class DigitalPlanning {
     return {
       site: annotatedBoundary as GeoJSON,
       area: {
+        // Sessions as of 8 Jan 25 use `proposal.site.area` while old ones use `property.boundary.area`
         hectares:
-          this.passport.data?.["proposal.siteArea.hectares"] ||
-          this.passport.data?.["proposal.site.area.hectares"],
+          this.passport.data?.["proposal.site.area.hectares"] ||
+          this.passport.data?.["proposal.boundary.area.hectares"],
         squareMetres:
-          this.passport.data?.["proposal.siteArea"] ||
-          this.passport.data?.["proposal.site.area"],
+          this.passport.data?.["proposal.site.area"] ||
+          this.passport.data?.["property.boundary.area"],
       },
     } as Payload["data"]["proposal"]["boundary"];
   }

--- a/src/export/oneApp/model.ts
+++ b/src/export/oneApp/model.ts
@@ -295,7 +295,11 @@ export class OneAppPayload {
       },
     ];
 
-    if (this.passport.data["proposal.site"]) {
+    // Sessions as of 8 Jan 25 use `proposal.site` while old ones use `property.boundary.site`
+    if (
+      this.passport.data["proposal.site"] ||
+      this.passport.data["property.boundary.site"]
+    ) {
       files.push({
         "common:FileName": "LocationPlanGeoJSON.geojson",
       });


### PR DESCRIPTION
Sessions submitted before yesterday that haven't been downloaded by council partners are:
- Failing to display maps
- Were omitted from "sessions" update in script because they aren't "active"

So, I think these fallback variables should allow both old & new submission documents to correctly display