### PR TITLE
feat: add new flow methods for ReadMePage work

### DIFF
--- a/src/requests/flow.ts
+++ b/src/requests/flow.ts
@@ -36,6 +36,10 @@ export class FlowClient {
     return setDescription(this.client, args);
   }
 
+  async setSummary(args: { flow: { id: string }; summary: string }) {
+    return setSummary(this.client, args);
+  }
+
   /**
    * Only used in test environments
    */
@@ -310,6 +314,13 @@ interface SetFlowDescription {
   };
 }
 
+interface SetFlowSummary {
+  flow: {
+    id: string;
+    summary: string;
+  };
+}
+
 async function setStatus(
   client: GraphQLClient,
   args: { flow: { id: string }; status: FlowStatus },
@@ -371,6 +382,37 @@ async function setDescription(
   } catch (error) {
     new Error(
       `Failed to update flow description to "${args.description}". Error: ${error}`,
+    );
+  }
+}
+
+async function setSummary(
+  client: GraphQLClient,
+  args: { flow: { id: string }; summary: string },
+) {
+  try {
+    const { flow } = await client.request<SetFlowSummary>(
+      gql`
+        mutation SetFlowSummary($flowId: uuid!, $summary: String!) {
+          flow: update_flows_by_pk(
+            pk_columns: { id: $flowId }
+            _set: { summary: $summary }
+          ) {
+            id
+            summary
+          }
+        }
+      `,
+      {
+        flowId: args.flow.id,
+        summary: args.summary,
+      },
+    );
+
+    return flow;
+  } catch (error) {
+    new Error(
+      `Failed to update flow summary to "${args.summary}". Error: ${error}`,
     );
   }
 }

--- a/src/requests/flow.ts
+++ b/src/requests/flow.ts
@@ -40,6 +40,10 @@ export class FlowClient {
     return setSummary(this.client, args);
   }
 
+  async setLimitations(args: { flow: { id: string }; limitations: string }) {
+    return setLimitations(this.client, args);
+  }
+
   /**
    * Only used in test environments
    */
@@ -321,6 +325,13 @@ interface SetFlowSummary {
   };
 }
 
+interface SetFlowLimitations {
+  flow: {
+    id: string;
+    limitations: string;
+  };
+}
+
 async function setStatus(
   client: GraphQLClient,
   args: { flow: { id: string }; status: FlowStatus },
@@ -413,6 +424,37 @@ async function setSummary(
   } catch (error) {
     new Error(
       `Failed to update flow summary to "${args.summary}". Error: ${error}`,
+    );
+  }
+}
+
+async function setLimitations(
+  client: GraphQLClient,
+  args: { flow: { id: string }; limitations: string },
+) {
+  try {
+    const { flow } = await client.request<SetFlowLimitations>(
+      gql`
+        mutation SetFlowLimitations($flowId: uuid!, $limitations: String!) {
+          flow: update_flows_by_pk(
+            pk_columns: { id: $flowId }
+            _set: { limitations: $limitations }
+          ) {
+            id
+            summary
+          }
+        }
+      `,
+      {
+        flowId: args.flow.id,
+        limitations: args.limitations,
+      },
+    );
+
+    return flow;
+  } catch (error) {
+    new Error(
+      `Failed to update flow limitations to "${args.limitations}". Error: ${error}`,
     );
   }
 }


### PR DESCRIPTION
### In this PR:

- add `setSummary` and `setLimitations` to `FlowClient` for updating the short summary in the ReadMePage.

This PR is a pre-requisite for: https://github.com/theopensystemslab/planx-new/pull/4145 and is associated with [this Trello ticket](https://trello.com/c/2FMdl5c3/3159-add-a-description-field-like-a-readme-page-for-all-flows).