### PR TITLE
chore: Drop deprecated `@mui/base` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@formatjs/intl-listformat": "^7.7.9",
-    "@mui/base": "5.0.0-beta.60",
     "@mui/material": "^5.15.10",
     "ajv-formats": "^2.1.1",
     "ajv": "^8.17.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,9 +19,6 @@ dependencies:
   '@formatjs/intl-listformat':
     specifier: ^7.7.9
     version: 7.7.9
-  '@mui/base':
-    specifier: 5.0.0-beta.60
-    version: 5.0.0-beta.60(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
   '@mui/material':
     specifier: ^5.15.10
     version: 5.15.10(@emotion/react@11.13.3)(@emotion/styled@11.13.0)(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
@@ -1438,29 +1435,6 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
     dev: false
 
-  /@mui/base@5.0.0-beta.60(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-w8twR3qCUI+uJHO5xDOuc1yB5l46KFbvNsTwIvEW9tQkKxVaiEFf2GAXHuvFJiHfZLqjzett6drZjghy8D1Z1A==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0
-      react: ^17.0.0 || ^18.0.0
-      react-dom: ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1)(react@18.3.1)
-      '@mui/types': 7.2.21(@types/react@18.3.12)
-      '@mui/utils': 6.4.1(@types/react@18.3.12)(react@18.3.1)
-      '@popperjs/core': 2.11.8
-      '@types/react': 18.3.12
-      clsx: 2.1.1
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    dev: false
-
   /@mui/core-downloads-tracker@5.16.14:
     resolution: {integrity: sha512-sbjXW+BBSvmzn61XyTMun899E7nGPTXwqD9drm1jBUAvWEhJpPFIRxwQQiATWZnd9rvdxtnhhdsDxEGWI0jxqA==}
     dev: false
@@ -1584,26 +1558,6 @@ packages:
   /@mui/utils@5.16.14(@types/react@18.3.12)(react@18.3.1):
     resolution: {integrity: sha512-wn1QZkRzSmeXD1IguBVvJJHV3s6rxJrfb6YuC9Kk6Noh9f8Fb54nUs5JRkKm+BOerRhj5fLg05Dhx/H3Ofb8Mg==}
     engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.26.0
-      '@mui/types': 7.2.21(@types/react@18.3.12)
-      '@types/prop-types': 15.7.14
-      '@types/react': 18.3.12
-      clsx: 2.1.1
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-is: 19.0.0
-    dev: false
-
-  /@mui/utils@6.4.1(@types/react@18.3.12)(react@18.3.1):
-    resolution: {integrity: sha512-iQUDUeYh87SvR4lVojaRaYnQix8BbRV51MxaV6MBmqthecQoxwSbS5e2wnbDJUeFxY2ppV505CiqPLtd0OWkqw==}
-    engines: {node: '>=14.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0


### PR DESCRIPTION
Hitting some build issue in `planx-new` which references this import via `planx-core`. The package is deprecated and unused, here's what I've checked - 
 - Library builds
 - Library passes tests
 - `pnpm examples` works
 - No references in code to `@mui/base`