### PR TITLE
fix: temporarily `skipValidation` for preApps

### DIFF
--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -105,7 +105,7 @@ export class DigitalPlanning {
   getPayload(
     skipValidation: boolean = false,
   ): ApplicationPayload | PreApplicationPayload {
-    if (skipValidation) {
+    if (skipValidation || this.applicationType === "preApp") {
       return this.payload;
     } else {
       this.validatePayload();


### PR DESCRIPTION
We've had two reports of failing preApp payloads in two days. Both cases are using "send to email" (& very unlikely the .json which when fails blocks the whole zip). 

I think it's worth considering if we should temporarily turn off preApp validation based on two big factors:
- George & the service's team work on a "preApp template" is still ongoing and until rolled out there's going to continue to be variance and surprises per council
- BOPS is not actually accepting preApps yet (when they start, we'll _have to_ validate payloads - but it honestly doesn't matter for our current send to email users I think?)