### PR TITLE
chore: add `flow._destroyPublishedAll` helper for E2E tests

### DIFF
--- a/src/requests/flow.ts
+++ b/src/requests/flow.ts
@@ -62,6 +62,10 @@ export class FlowClient {
   async _destroyPublished(publishedFlowId: number): Promise<boolean> {
     return _destroyPublishedFlow(this.client, publishedFlowId);
   }
+
+  async _destroyPublishedAll(): Promise<boolean> {
+    return _destroyAllPublishedFlows(this.client);
+  }
 }
 
 export async function getLatestFlowGraph(
@@ -319,6 +323,22 @@ export async function _destroyPublishedFlow(
       { publishedFlowId },
     );
   return Boolean(response.delete_published_flows_by_pk?.id);
+}
+
+export async function _destroyAllPublishedFlows(
+  client: GraphQLClient,
+): Promise<boolean> {
+  const response: { deletePublishedFlows: { affectedRows: string } } =
+    await client.request(gql`
+      mutation DestroyAllPublishedFlows {
+        deletePublishedFlows: delete_published_flows(
+          where: { id: { _is_null: false } }
+        ) {
+          affectedRows: affected_rows
+        }
+      }
+    `);
+  return Boolean(response.deletePublishedFlows.affectedRows);
 }
 
 interface SetFlowStatus {


### PR DESCRIPTION
Now that flows are published on create, we need to add additional cleanup steps to our E2E API regression tests. There will also now be instances of _more than one_ published flow associated with a flow during a single test, so it's ideal to have a `destroyPublishedAll` helper here. 

Currently failing with error: `Error: Foreign key violation. update or delete on table "users" violates foreign key constraint "published_flows_publisher_id_fkey" on table "published_flows"`
```
{
  "response": {
    "errors": [{
      "message": "Foreign key violation. update or delete on table \"users\" violates foreign key constraint \"published_flows_publisher_id_fkey\" on table \"published_flows\"",
      "extensions": {
        "path":"$",
        "code":"constraint-violation"
      }
    }],
    "status":200,
    "headers":{}
  },
  "request": {
    "query": "mutation DestroyAllUsers {
          deleteUsers: delete_users(where: { id: { _is_null: false } }) {
            affectedRows: affected_rows
        }
      }
    "
  }
}
```