### PR TITLE
fix: Error handling for negative reductions

### DIFF
--- a/src/utils/feeBreakdown.test.ts
+++ b/src/utils/feeBreakdown.test.ts
@@ -333,7 +333,7 @@ describe("getFeeBreakdown() function", () => {
   });
 
   describe("invalid inputs", () => {
-    it("returns undefined for missing data", () => {
+    it("throws an error for missing data", () => {
       const mockPassportData = {
         "some.other.fields": ["abc", "xyz"],
       };
@@ -341,7 +341,7 @@ describe("getFeeBreakdown() function", () => {
       expect(() => getFeeBreakdown(mockPassportData)).toThrow();
     });
 
-    it("returns undefined for partial data", () => {
+    it("throws an error for partial data", () => {
       const mockPassportData = {
         "application.fee.calculated": [1000],
         "application.fee.payable.includesVAT": ["true"],
@@ -351,7 +351,7 @@ describe("getFeeBreakdown() function", () => {
       expect(() => getFeeBreakdown(mockPassportData)).toThrow();
     });
 
-    it("returns undefined for incorrect data", () => {
+    it("throws an error for incorrect data", () => {
       const mockPassportData = {
         "application.fee.calculated": "some string",
         "application.fee.payable": [800, 700],
@@ -360,6 +360,27 @@ describe("getFeeBreakdown() function", () => {
       };
 
       expect(() => getFeeBreakdown(mockPassportData)).toThrow();
+    });
+
+    it("throws an error for a negative reduction", () => {
+      const mockPassportData = {
+        "proposal.siteArea": "0",
+        "application.type": ["pp.full.householder"],
+        "application.fee.calculated": 258,
+        multipleFees: ["false"],
+        "application.fee.exemption.disability": ["false"],
+        "proposal.projectType": ["unit"],
+        "property.type": ["commercial.leisure.sport.recreationGround"],
+        "application.fee.reduction.sports": ["true"],
+        "application.fee.reduction.parishCouncil": ["false"],
+        "application.fee.reduction.alternative": ["true"],
+        "application.fee.payable": 578,
+        "application.fee.payable.includesVAT": ["true"],
+      };
+
+      expect(() => getFeeBreakdown(mockPassportData)).toThrow(
+        "Reduction should always be negative",
+      );
     });
   });
 });

--- a/src/utils/feeBreakdown.ts
+++ b/src/utils/feeBreakdown.ts
@@ -62,6 +62,10 @@ export const calculateReductionOrExemptionAmounts = (
     ? data["application.fee.calculated"] - data["application.fee.payable"]
     : 0;
 
+  // A negative reduction indicates a content issues with passport variables
+  // "application.fee.calculated" should always be greater than "application.fee.payable"
+  if (reduction < 0) throw Error("Reduction should always be negative");
+
   return {
     exemption: 0,
     reduction: reduction,


### PR DESCRIPTION
Please see https://opensystemslab.slack.com/archives/C07F7215W7P/p1739350959482879 for context (OSL Slack).

Negative reductions should not happen and would be indicative of a content error (something incorrectly marked as a reduction when it is not).

This just adds a guard for this edge case, which will result in the fee breakdown not displaying for an applicant.