### PR TITLE
Revert "fix: temporarily `skipValidation` for preApps"

### DIFF
--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -107,7 +107,7 @@ export class DigitalPlanning {
   getPayload(
     skipValidation: boolean = false,
   ): ApplicationPayload | PreApplicationPayload {
-    if (skipValidation || this.applicationType === "preApp") {
+    if (skipValidation) {
       return this.payload;
     } else {
       this.validatePayload();


### PR DESCRIPTION
Reverts theopensystemslab/planx-core#641

Camden is preparing to go live with pre-apps. See ticket: https://trello.com/c/K7qtyE1t/3259-resolve-validation-issues-for-pre-application-payloads