### PR TITLE
feat: add `serviceCharge`, `fastTrack` and total `vat` amounts to fee breakdown

### DIFF
--- a/src/types/feeBreakdown.ts
+++ b/src/types/feeBreakdown.ts
@@ -32,5 +32,5 @@ export interface PassportFeeFields {
   "application.fee.serviceCharge.VAT"?: number;
   "application.fee.fastTrack"?: number;
   "application.fee.fastTrack.VAT"?: number;
-  // `${string}.VAT`?: string;
+  [key: `${string}.VAT`]: number | undefined;
 }

--- a/src/types/feeBreakdown.ts
+++ b/src/types/feeBreakdown.ts
@@ -2,7 +2,9 @@ export interface FeeBreakdown {
   amount: {
     calculated: number;
     payable: number;
-    vat: number;
+    vat?: number;
+    serviceCharge?: number;
+    fastTrack?: number;
   } & ReductionOrExemption;
   reductions: string[];
   exemptions: string[];
@@ -21,10 +23,14 @@ export type ReductionOrExemption =
 export interface PassportFeeFields {
   "application.fee.calculated": number;
   "application.fee.payable": number;
-  "application.fee.payable.includesVAT": boolean;
   "application.fee.reduction.alternative": boolean;
   "application.fee.reduction.parishCouncil": boolean;
   "application.fee.reduction.sports": boolean;
   "application.fee.exemption.disability": boolean;
   "application.fee.exemption.resubmission": boolean;
+  "application.fee.serviceCharge"?: number;
+  "application.fee.serviceCharge.VAT"?: number;
+  "application.fee.fastTrack"?: number;
+  "application.fee.fastTrack.VAT"?: number;
+  // `${string}.VAT`?: string;
 }

--- a/src/utils/feeBreakdown.test.ts
+++ b/src/utils/feeBreakdown.test.ts
@@ -74,6 +74,25 @@ describe("calculateReductionOrExemption() helper function", () => {
     expect(reduction).toEqual(0);
     expect(exemption).toEqual(100);
   });
+
+  it("correctly outputs a 0 reduction when payable is greater than calculated due to a service charge", () => {
+    const input: PassportFeeFields = {
+      "application.fee.calculated": 100,
+      "application.fee.payable": 136,
+      "application.fee.serviceCharge": 30,
+      "application.fee.serviceCharge.VAT": 6,
+      "application.fee.reduction.alternative": false,
+      "application.fee.reduction.parishCouncil": false,
+      "application.fee.reduction.sports": false,
+      "application.fee.exemption.disability": false,
+      "application.fee.exemption.resubmission": false,
+    };
+    const { reduction, exemption } =
+      calculateReductionOrExemptionAmounts(input);
+
+    expect(reduction).toEqual(0);
+    expect(exemption).toEqual(0);
+  });
 });
 
 describe("sumVAT() helper function", () => {

--- a/src/utils/feeBreakdown.test.ts
+++ b/src/utils/feeBreakdown.test.ts
@@ -111,10 +111,10 @@ describe("sumVAT() helper function", () => {
     expect(sum).toEqual(46);
   });
 
-  it.skip("outputs the sum of known and dynamic passport VAT keys", () => {
+  it("outputs the sum of known and dynamic passport VAT keys", () => {
     const input: PassportFeeFields = {
       "application.fee.calculated": 100,
-      "application.fee.calculated.VAT": 20, // TODO !!
+      "application.fee.calculated.VAT": 20, // eg pre-apps charge VAT on the whole application fee
       "application.fee.payable": 376,
       "application.fee.serviceCharge": 30,
       "application.fee.serviceCharge.VAT": 6,

--- a/src/utils/feeBreakdown.ts
+++ b/src/utils/feeBreakdown.ts
@@ -6,8 +6,6 @@ import {
   ReductionOrExemption,
 } from "../types/index.js";
 
-export const VAT_RATE = 0.2;
-
 export const toNumber = (input: number | [number]) =>
   Array.isArray(input) ? input[0] : input;
 
@@ -129,7 +127,6 @@ export const createPassportSchema = () => {
       "application.fee.serviceCharge.VAT": feeSchema.optional().default(0),
       "application.fee.fastTrack": feeSchema.optional().default(0),
       "application.fee.fastTrack.VAT": feeSchema.optional().default(0),
-      // `${z.string()}.VAT`: feeSchema.optional().default(0),
       "application.fee.reduction.alternative": booleanSchema,
       "application.fee.reduction.parishCouncil": booleanSchema,
       "application.fee.reduction.sports": booleanSchema,

--- a/src/utils/feeBreakdown.ts
+++ b/src/utils/feeBreakdown.ts
@@ -55,8 +55,15 @@ export const calculateReductionOrExemptionAmounts = (
     };
   }
 
+  // Reductions should exclude extra VAT-able charges & fees
+  const extraCharges =
+    (data["application.fee.serviceCharge"] || 0) +
+    (data["application.fee.fastTrack"] || 0) +
+    sumVAT(data); // sumVAT() accounts for dynamic and static `.VAT` keys
+
   const reduction = data["application.fee.calculated"]
-    ? data["application.fee.calculated"] - data["application.fee.payable"]
+    ? data["application.fee.calculated"] -
+      (data["application.fee.payable"] - extraCharges)
     : 0;
 
   // A negative reduction indicates a content issues with passport variables

--- a/src/utils/feeBreakdown.ts
+++ b/src/utils/feeBreakdown.ts
@@ -106,40 +106,52 @@ export const toFeeBreakdown = (data: PassportFeeFields): FeeBreakdown => ({
   ...getReductionOrExemptionLists(data),
 });
 
-export const createPassportSchema = () => {
-  const questionSchema = z.number().nonnegative();
-  const setValueSchema = z.tuple([z.coerce.number().nonnegative()]);
-  const feeSchema = z
-    .union([questionSchema, setValueSchema])
-    .transform(toNumber);
+const questionSchema = z.number().nonnegative();
+const setValueSchema = z.tuple([z.coerce.number().nonnegative()]);
+const feeSchema = z.union([questionSchema, setValueSchema]).transform(toNumber);
 
-  /** Describes how boolean values are set via PlanX components */
-  const booleanSchema = z
-    .tuple([z.enum(["true", "false"])])
-    .default(["false"])
-    .transform(toBoolean);
+/** Describes how boolean values are set via PlanX components */
+const booleanSchema = z
+  .tuple([z.enum(["true", "false"])])
+  .default(["false"])
+  .transform(toBoolean);
 
-  const schema = z
-    .object({
-      "application.fee.calculated": feeSchema.optional().default(0),
-      "application.fee.payable": feeSchema,
-      "application.fee.serviceCharge": feeSchema.optional().default(0),
-      "application.fee.serviceCharge.VAT": feeSchema.optional().default(0),
-      "application.fee.fastTrack": feeSchema.optional().default(0),
-      "application.fee.fastTrack.VAT": feeSchema.optional().default(0),
-      "application.fee.reduction.alternative": booleanSchema,
-      "application.fee.reduction.parishCouncil": booleanSchema,
-      "application.fee.reduction.sports": booleanSchema,
-      "application.fee.exemption.disability": booleanSchema,
-      "application.fee.exemption.resubmission": booleanSchema,
-    })
-    .transform(toFeeBreakdown);
+/** Static fee-associated passport fields */
+export const staticSchema = z.object({
+  "application.fee.calculated": feeSchema.optional().default(0),
+  "application.fee.payable": feeSchema,
+  "application.fee.serviceCharge": feeSchema.optional().default(0),
+  "application.fee.serviceCharge.VAT": feeSchema.optional().default(0),
+  "application.fee.fastTrack": feeSchema.optional().default(0),
+  "application.fee.fastTrack.VAT": feeSchema.optional().default(0),
+  "application.fee.reduction.alternative": booleanSchema,
+  "application.fee.reduction.parishCouncil": booleanSchema,
+  "application.fee.reduction.sports": booleanSchema,
+  "application.fee.exemption.disability": booleanSchema,
+  "application.fee.exemption.resubmission": booleanSchema,
+});
 
-  return schema;
-};
+/**
+ * Dynamic fee-associated passport fields
+ * Consist of a user-defined variable, plus a ".VAT" suffix
+ */
+const dynamicSchema = z.record(
+  z.string().endsWith(".VAT"),
+  feeSchema.optional().default(0),
+);
 
+/**
+ * Generate schemas, parse passport, then transform to a FeeBreakdown object
+ */
 export const getFeeBreakdown = (passportData: unknown): FeeBreakdown => {
-  const schema = createPassportSchema();
-  const result = schema.parse(passportData);
+  // Zod does not allow z.object() (static object) and z.record() (dynamic object) to be merged as a single schema
+  // To work around this, we follow a two-step process -
+  //   - First strictly parse the static values
+  //   - Then safely parse the dynamic values
+  const staticResult = staticSchema.parse(passportData);
+  const dynamicResult = dynamicSchema.safeParse(passportData);
+
+  const result = toFeeBreakdown({ ...staticResult, ...dynamicResult });
+
   return result;
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 export * from "./digitalPlanningSchema.js";
 export * from "./encryption.js";
-export { getFeeBreakdown, VAT_RATE } from "./feeBreakdown.js";
+export { getFeeBreakdown } from "./feeBreakdown.js";
 export * from "./govPayMetadata.js";
 export * from "./projectTypes.js";


### PR DESCRIPTION
Supports https://github.com/theopensystemslab/planx-new/pull/4508

Use https://4508.planx.pizza/testing/set-fee-demo for passport mocks