### PR TITLE
fix: updated `parking` mappings for ODP Schema

### DIFF
--- a/src/export/digitalPlanning/mocks/planningPermission.ts
+++ b/src/export/digitalPlanning/mocks/planningPermission.ts
@@ -15,6 +15,23 @@ export const mockPlanningPermissionSession = {
   sanitised_at: null,
   email: "example@example.com",
   passport: {
+    "proposal.parking": [
+      {
+        type: "cars",
+        existing: 0,
+        proposed: 1,
+      },
+      {
+        type: "disabled",
+        existing: 1,
+        proposed: 0,
+      },
+      {
+        type: "cycles",
+        existing: 1,
+        proposed: 3,
+      },
+    ],
     "proposal.materials": [
       {
         type: "window",

--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -1,7 +1,7 @@
 import { default as Ajv } from "ajv/dist/ajv.js";
 import { default as addFormats } from "ajv-formats/dist/index.js";
 import { Feature } from "geojson";
-import { difference, set } from "lodash-es";
+import { set } from "lodash-es";
 
 import { Passport } from "../../models/index.js";
 import { getResultData } from "../../models/result.js";

--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -52,18 +52,6 @@ import {
 import preApplicationJsonSchema from "./schemas/preApplication/schema.json" with { type: "json" };
 import { PreApplication as PreApplicationPayload } from "./schemas/preApplication/types.js";
 
-const PARKING_TYPES = [
-  "cars",
-  "vans",
-  "motorcycles",
-  "cycles",
-  "buses",
-  "disabled",
-  "carClub",
-  "offStreet.residential",
-  "other",
-];
-
 // These application types will never use london-data-hub
 //   See https://docs.google.com/spreadsheets/d/1FgULPemnwuwysrYGEkReYFXz3n3T7W0nWziU00taZE4/edit?gid=0#gid=0
 const applicationTypesWithoutGLASpec = [


### PR DESCRIPTION
Flagged yesterday by Meera - see `proposal.parking` in this example payload https://api.editor.planx.dev/admin/session/23f28a34-8ec3-473c-ad69-92734deba1f4/summary which incorrectly populated as "0"s in actual `/digital-planning-application` shape (no validation error)

This change fixes the passport mappings - but still only for London councils. It's highlighted an additional gap in our underlying types that don't correctly account for non-GLA parking with uses a different/separate Planx List Schema https://github.com/theopensystemslab/digital-planning-data-schemas/blob/main/types/shared/Parking.ts - we'll pick up this in the next schema release, but I'm hopeful it shouldn't be an issue for any live services in the meantime.