### PR TITLE
chore: Use Zod's `safeParse()` instead of `parse()` for better error handling and formatting

### DIFF
--- a/src/export/bops/utils/index.ts
+++ b/src/export/bops/utils/index.ts
@@ -38,7 +38,15 @@ export const parseNodeData = (node: Node) => {
       ),
     }),
   });
-  const nodeData = componentSchema.parse(node.data);
+  const result = componentSchema.safeParse(node.data);
+
+  if (!result.success) {
+    throw Error("Failed to parse node data", {
+      cause: result.error.flatten(),
+    });
+  }
+
+  const nodeData = result.data;
   return nodeData;
 };
 

--- a/src/export/bops/utils/mapAndLabel.ts
+++ b/src/export/bops/utils/mapAndLabel.ts
@@ -35,7 +35,15 @@ export const parseResponses = (fn: string, crumb: EnrichedCrumb) => {
     }),
   });
 
-  const crumbData = crumbDataSchema.parse(crumb.data);
+  const result = crumbDataSchema.safeParse(crumb.data);
+
+  if (!result.success) {
+    throw Error("Failed to parse response data for MapAndLabel", {
+      cause: result.error.flatten(),
+    });
+  }
+
+  const crumbData = result.data;
   const schemaResponses = crumbData[fn];
   return schemaResponses;
 };

--- a/src/export/bops/utils/schema.ts
+++ b/src/export/bops/utils/schema.ts
@@ -53,7 +53,15 @@ export const parseResponses = (fn: string, crumb: EnrichedCrumb) => {
   const crumbDataSchema = z.object({
     [fn]: z.array(z.record(schemaResponsesSchema)),
   });
-  const crumbData = crumbDataSchema.parse(crumb.data);
+  const result = crumbDataSchema.safeParse(crumb.data);
+
+  if (!result.success) {
+    throw Error("Failed to parse response data", {
+      cause: result.error.flatten(),
+    });
+  }
+
+  const crumbData = result.data;
   const schemaResponses = crumbData[fn];
   return schemaResponses;
 };

--- a/src/utils/feeBreakdown.test.ts
+++ b/src/utils/feeBreakdown.test.ts
@@ -338,7 +338,19 @@ describe("getFeeBreakdown() function", () => {
         "some.other.fields": ["abc", "xyz"],
       };
 
-      expect(() => getFeeBreakdown(mockPassportData)).toThrow();
+      expect(() => getFeeBreakdown(mockPassportData)).toThrowError(
+        expect.objectContaining({
+          message: expect.stringMatching(/Failed to parse fee breakdown data/),
+          cause: expect.objectContaining({
+            fieldErrors: expect.objectContaining({
+              "application.fee.payable": expect.arrayContaining([
+                "Invalid input",
+              ]),
+            }),
+            formErrors: expect.any(Array),
+          }),
+        }),
+      );
     });
 
     it("throws an error for partial data", () => {
@@ -348,7 +360,19 @@ describe("getFeeBreakdown() function", () => {
         "some.other.fields": ["abc", "xyz"],
       };
 
-      expect(() => getFeeBreakdown(mockPassportData)).toThrow();
+      expect(() => getFeeBreakdown(mockPassportData)).toThrowError(
+        expect.objectContaining({
+          message: expect.stringMatching(/Failed to parse fee breakdown data/),
+          cause: expect.objectContaining({
+            fieldErrors: expect.objectContaining({
+              "application.fee.payable": expect.arrayContaining([
+                "Invalid input",
+              ]),
+            }),
+            formErrors: expect.any(Array),
+          }),
+        }),
+      );
     });
 
     it("throws an error for incorrect data", () => {
@@ -359,7 +383,25 @@ describe("getFeeBreakdown() function", () => {
         "some.other.fields": ["abc", "xyz"],
       };
 
-      expect(() => getFeeBreakdown(mockPassportData)).toThrow();
+      expect(() => getFeeBreakdown(mockPassportData)).toThrowError(
+        expect.objectContaining({
+          message: expect.stringMatching(/Failed to parse fee breakdown data/),
+          cause: expect.objectContaining({
+            fieldErrors: expect.objectContaining({
+              "application.fee.calculated": expect.arrayContaining([
+                "Invalid input",
+              ]),
+              "application.fee.payable": [
+                "Array must contain at most 1 element(s)",
+              ],
+              "application.fee.payable.includesVAT": [
+                "Expected array, received boolean",
+              ],
+            }),
+            formErrors: expect.any(Array),
+          }),
+        }),
+      );
     });
 
     it("throws an error for a negative reduction", () => {

--- a/src/utils/feeBreakdown.ts
+++ b/src/utils/feeBreakdown.ts
@@ -136,6 +136,13 @@ export const createPassportSchema = () => {
 
 export const getFeeBreakdown = (passportData: unknown): FeeBreakdown => {
   const schema = createPassportSchema();
-  const result = schema.parse(passportData);
-  return result;
+  const result = schema.safeParse(passportData);
+
+  if (!result.success) {
+    throw Error("Failed to parse fee breakdown data", {
+      cause: result.error.flatten(),
+    });
+  }
+
+  return result.data;
 };


### PR DESCRIPTION
## What does this PR do?
 - Uses Zod's `safeParse()` instead of `parse()` to allow us to `.flatten()` (format) errors into a more readable format
   - The `safeParse()` pattern seems a little cleaner than wrapping `try/catch` blocks everywhere
   - The default Zod error (a list of issues) is comprehensive, but hard to read - `.flatten()` gives a nicer format we can more easily match to the input object
   - Docs: https://zod.dev/ERROR_HANDLING?id=formatting-errors

## Context
This steps from the following discussion - https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1744009225907769 (OSL Slack)