### PR TITLE
fix: account for `ldc.listedBuildingWorks` having application fee `notApplicable`

### DIFF
--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -763,7 +763,10 @@ export class DigitalPlanning {
     const hasPayComponent = Object.values(this.flow).find(
       (node: Node) => node?.type === ComponentType.Pay,
     );
-    if (!hasPayComponent) {
+    if (
+      !hasPayComponent ||
+      this.applicationType === "ldc.listedBuildingWorks"
+    ) {
       return {
         notApplicable: true,
       };
@@ -1224,7 +1227,10 @@ export class DigitalPlanning {
     const hasPayComponent = Object.values(this.flow).find(
       (node: Node) => node?.type === ComponentType.Pay,
     );
-    if (!hasPayComponent) {
+    if (
+      !hasPayComponent ||
+      this.applicationType === "ldc.listedBuildingWorks"
+    ) {
       return {
         notApplicable: true,
       };

--- a/src/export/oneApp/model.ts
+++ b/src/export/oneApp/model.ts
@@ -332,8 +332,10 @@ export class OneAppPayload {
       GOV_PAY_PASSPORT_KEY
     ] as unknown as GovUKPayment;
     return {
-      "common:AmountDue": this.passport.number(["application.fee.payable"]),
-      "common:AmountPaid": payment?.amount,
+      "common:AmountDue": this.passport.data["application.fee.payable"]
+        ? this.passport.number(["application.fee.payable"])
+        : 0,
+      "common:AmountPaid": payment?.amount || 0,
     };
   }
 


### PR DESCRIPTION
The service as a whole has a Pay component, but this single journey within it is not "fee carrying". See https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1744359684053329