### PR TITLE
fix: `ldc.listedBuildingWorks` application types won't have PP flagset

### DIFF
--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -888,7 +888,8 @@ export class DigitalPlanning {
     // Planning Permission application types won't have a Planning Permission result right now
     if (
       this.applicationType?.startsWith("pp") ||
-      this.applicationType === "listed"
+      this.applicationType === "listed" ||
+      this.applicationType === "ldc.listedBuildingWorks"
     ) {
       return undefined;
     } else {


### PR DESCRIPTION
Context https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1744369024067619?thread_ts=1744359684.053329&cid=C088K9ZL8EA