### PR TITLE
fix: Use strict boolean in  `UpdateTeamSettings` mutation

### DIFF
--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -481,7 +481,7 @@ async function updateTeamSettings(
         submission_email: teamSettings.submissionEmail,
         is_trial: teamSettings.isTrial,
       },
-      toggle_flows_offline: teamSettings.isTrial,
+      toggle_flows_offline: Boolean(teamSettings.isTrial),
     },
   );
 


### PR DESCRIPTION
Implemented in https://github.com/theopensystemslab/planx-new/pull/4605

The mutation requires that a strict boolean is passed in, it's not casting / inferring `false` based on a falsy value being passed in.