### PR TITLE
fix: preserve calculated fee = 0 in breakdowns

### DIFF
--- a/src/utils/feeBreakdown.test.ts
+++ b/src/utils/feeBreakdown.test.ts
@@ -214,14 +214,16 @@ describe("toFeeBreakdown() helper function", () => {
     );
   });
 
-  it("sets calculated to payable amount if no calculated value is provided", () => {
+  it("does not set calculated to payable amount if no calculated value is provided", () => {
+    // It's valid to have initial calculated application fee = 0, but Fast Track - so payable > 0
+    //   Fee breakdown display should correctly preserve "Application fee = 0"
     const input: PassportFeeFields = {
       "application.fee.calculated": 0,
       "application.fee.calculated.VAT": 0,
-      "application.fee.payable": 50,
+      "application.fee.payable": 90,
       "application.fee.payable.VAT": 0,
-      "application.fee.fastTrack": 0,
-      "application.fee.fastTrack.VAT": 0,
+      "application.fee.fastTrack": 75,
+      "application.fee.fastTrack.VAT": 15,
       "application.fee.serviceCharge": 0,
       "application.fee.serviceCharge.VAT": 0,
       "application.fee.paymentProcessing": 0,
@@ -235,7 +237,8 @@ describe("toFeeBreakdown() helper function", () => {
 
     const { amount } = toFeeBreakdown(input);
 
-    expect(amount.calculated).toEqual(input["application.fee.payable"]);
+    expect(amount.calculated).toEqual(input["application.fee.calculated"]);
+    expect(amount.payable).toEqual(input["application.fee.payable"]);
   });
 });
 

--- a/src/utils/feeBreakdown.ts
+++ b/src/utils/feeBreakdown.ts
@@ -104,7 +104,7 @@ const getReductionOrExemptionLists = (data: PassportFeeFields) => {
  */
 export const toFeeBreakdown = (data: PassportFeeFields): FeeBreakdown => ({
   amount: {
-    calculated: getCalculatedAmount(data),
+    calculated: data["application.fee.calculated"],
     calculatedVAT: data["application.fee.calculated.VAT"],
     payable: data["application.fee.payable"],
     payableVAT: data["application.fee.payable.VAT"],


### PR DESCRIPTION
See error report here https://opensystemslab.slack.com/archives/C07F7215W7P/p1746545457127259?thread_ts=1746524633.032529&cid=C07F7215W7P