### PR TITLE
fix: ensure that `articleFour` values for hyphenated teams are still handled properly in ODP Schema mappings

### DIFF
--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -694,7 +694,13 @@ export class DigitalPlanning {
   }
 
   private getPlanningConstraints(): ApplicationPayload["data"]["property"]["planning"] {
-    const teamSlug: string = this.metadata.flow.team.slug;
+    let teamSlug: string = this.metadata.flow.team.slug;
+    // This is hacky but solves current cases where councilName segment differs from team-slug (eg `articleFour.councilName.recordName`)
+    if (teamSlug === "barking-and-dagenham") teamSlug = "barkingAndDagenham";
+    if (teamSlug === "epsom-and-ewell") teamSlug = "epsomAndEwell";
+    if (teamSlug === "st-albans") teamSlug = "stAlbans";
+    if (teamSlug === "west-berkshire") teamSlug = "westBerkshire";
+
     const constraints = this.passport.data
       ?._constraints as unknown as EnhancedGISResponse[];
     const designations: PlanningDesignation[] = [];


### PR DESCRIPTION
When we populate the ODP Schema planning constraints, we want to only include top-level `articleFour` with `entities` and omit the PlanX-specific passport values to avoid having to manage these in schema enums.

This recent Epsom & Ewell error raised a small bug in how team slugs with hyphens were being incorrectly handled. https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1747036496136039

This a hacky fix, one to revisit more thoughtfully sometime ! 