### PR TITLE
feat: ODP Schema v0.7.5 (application & pre-application only)

### DIFF
--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -593,6 +593,7 @@ export class DigitalPlanning {
       localAuthorityDistrict:
         this.passport.data?.["property.localAuthorityDistrict"],
       region: this.passport.data?.["property.region"]?.[0],
+      ward: this.passport.data?.["property.ward"]?.[0] || "Ward not found", // fallback while old sessions may not yet have value from planning.data
       type: {
         value: this.passport.data?.["property.type"]?.[0],
         description: this.findDescriptionFromValue(

--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -47,7 +47,6 @@ import {
   Proposal,
   ProposedLondonParking,
   RequestedFiles,
-  SiteContactOther,
 } from "./schemas/application/types.js";
 import preApplicationJsonSchema from "./schemas/preApplication/schema.json" with { type: "json" };
 import { PreApplication as PreApplicationPayload } from "./schemas/preApplication/types.js";

--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -47,7 +47,7 @@ import {
   Proposal,
   ProposedLondonParking,
   RequestedFiles,
-  SiteContact,
+  SiteContactOther,
 } from "./schemas/application/types.js";
 import preApplicationJsonSchema from "./schemas/preApplication/schema.json" with { type: "json" };
 import { PreApplication as PreApplicationPayload } from "./schemas/preApplication/types.js";
@@ -522,7 +522,7 @@ export class DigitalPlanning {
       };
     } else {
       return {
-        role: siteContactRole satisfies SiteContact["role"],
+        role: siteContactRole,
       };
     }
   }

--- a/src/export/digitalPlanning/schemas/application/schema.json
+++ b/src/export/digitalPlanning/schemas/application/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "v0.7.4",
+  "$id": "v0.7.5",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "definitions": {
@@ -101,7 +101,28 @@
           "$ref": "#/definitions/Email"
         },
         "maintenanceContact": {
-          "$ref": "#/definitions/MaintenanceContacts"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "address": {
+                "$ref": "#/definitions/Address"
+              },
+              "contact": {
+                "$ref": "#/definitions/ContactDetails"
+              },
+              "when": {
+                "enum": [
+                  "duringConstruction",
+                  "afterConstruction",
+                  "duringAndAfterConstruction"
+                ],
+                "type": "string"
+              }
+            },
+            "required": ["when", "address", "contact"],
+            "type": "object"
+          },
+          "type": "array"
         },
         "name": {
           "additionalProperties": false,
@@ -133,7 +154,22 @@
           "type": "object"
         },
         "siteContact": {
-          "$ref": "#/definitions/SiteContact"
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "role": {
+                  "enum": ["applicant", "agent", "proxy"],
+                  "type": "string"
+                }
+              },
+              "required": ["role"],
+              "type": "object"
+            },
+            {
+              "$ref": "#/definitions/SiteContactOther"
+            }
+          ]
         },
         "type": {
           "enum": [
@@ -1847,7 +1883,28 @@
           "$ref": "#/definitions/Email"
         },
         "maintenanceContact": {
-          "$ref": "#/definitions/MaintenanceContacts"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "address": {
+                "$ref": "#/definitions/Address"
+              },
+              "contact": {
+                "$ref": "#/definitions/ContactDetails"
+              },
+              "when": {
+                "enum": [
+                  "duringConstruction",
+                  "afterConstruction",
+                  "duringAndAfterConstruction"
+                ],
+                "type": "string"
+              }
+            },
+            "required": ["when", "address", "contact"],
+            "type": "object"
+          },
+          "type": "array"
         },
         "name": {
           "additionalProperties": false,
@@ -1879,7 +1936,22 @@
           "type": "object"
         },
         "siteContact": {
-          "$ref": "#/definitions/SiteContact"
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "role": {
+                  "enum": ["applicant", "agent", "proxy"],
+                  "type": "string"
+                }
+              },
+              "required": ["role"],
+              "type": "object"
+            },
+            {
+              "$ref": "#/definitions/SiteContactOther"
+            }
+          ]
         },
         "type": {
           "enum": [
@@ -5701,7 +5773,8 @@
             {
               "$ref": "#/definitions/OSAddress"
             }
-          ]
+          ],
+          "description": "The property address"
         },
         "boundary": {
           "$ref": "#/definitions/GeoBoundary",
@@ -5811,8 +5884,8 @@
           "type": "object"
         },
         "region": {
-          "const": "London",
-          "type": "string"
+          "$ref": "#/definitions/Region",
+          "description": "Name of the region sourced from planning.data.gov.uk/dataset/region; \"London\" is a proxy for the Greater London Authority"
         },
         "socialLandlord": {
           "anyOf": [
@@ -5898,9 +5971,19 @@
           },
           "required": ["description"],
           "type": "object"
+        },
+        "ward": {
+          "description": "Name of the ward sourced from planning.data.gov.uk/dataset/ward",
+          "type": "string"
         }
       },
-      "required": ["address", "localAuthorityDistrict", "region", "type"],
+      "required": [
+        "address",
+        "localAuthorityDistrict",
+        "region",
+        "type",
+        "ward"
+      ],
       "type": "object"
     },
     "LondonProposal": {
@@ -6715,32 +6798,6 @@
       "required": ["description", "projectType"],
       "type": "object"
     },
-    "MaintenanceContacts": {
-      "description": "Contact information for the person(s) responsible for maintenance while the works are carried out",
-      "items": {
-        "additionalProperties": false,
-        "properties": {
-          "address": {
-            "$ref": "#/definitions/Address"
-          },
-          "contact": {
-            "$ref": "#/definitions/ContactDetails"
-          },
-          "when": {
-            "enum": [
-              "duringConstruction",
-              "afterConstruction",
-              "duringAndAfterConstruction"
-            ],
-            "type": "string"
-          }
-        },
-        "required": ["when", "address", "contact"],
-        "type": "object"
-      },
-      "title": "Maintenance contacts",
-      "type": "array"
-    },
     "Materials": {
       "additionalProperties": false,
       "properties": {
@@ -7304,7 +7361,14 @@
       "title": "#Owners"
     },
     "OwnersInterest": {
-      "enum": ["owner", "lessee", "occupier", "other"],
+      "enum": [
+        "owner",
+        "owner.sole",
+        "owner.co",
+        "lessee",
+        "occupier",
+        "other"
+      ],
       "type": "string"
     },
     "OwnersNoNoticeGiven": {
@@ -7397,19 +7461,7 @@
           "type": "object"
         },
         "interest": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/OwnersInterest"
-            },
-            {
-              "const": "owner.sole",
-              "type": "string"
-            },
-            {
-              "const": "owner.co",
-              "type": "string"
-            }
-          ]
+          "$ref": "#/definitions/OwnersInterest"
         },
         "interestDescription": {
           "type": "string"
@@ -25368,26 +25420,6 @@
       ],
       "description": "The result of a single flagset"
     },
-    "SiteContact": {
-      "anyOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "role": {
-              "enum": ["applicant", "agent", "proxy"],
-              "type": "string"
-            }
-          },
-          "required": ["role"],
-          "type": "object"
-        },
-        {
-          "$ref": "#/definitions/SiteContactOther"
-        }
-      ],
-      "description": "Contact information for the site visit",
-      "title": "Site contact"
-    },
     "SiteContactOther": {
       "additionalProperties": false,
       "description": "Contact information for the site visit when the SiteContact's role is 'other'",
@@ -25407,6 +25439,7 @@
         }
       },
       "required": ["role", "name", "email", "phone"],
+      "title": "Site contact other",
       "type": "object"
     },
     "UKProperty": {
@@ -25422,7 +25455,8 @@
             {
               "$ref": "#/definitions/OSAddress"
             }
-          ]
+          ],
+          "description": "The property address"
         },
         "boundary": {
           "$ref": "#/definitions/GeoBoundary",
@@ -25505,7 +25539,8 @@
           "type": "object"
         },
         "region": {
-          "$ref": "#/definitions/Region"
+          "$ref": "#/definitions/Region",
+          "description": "Name of the region sourced from planning.data.gov.uk/dataset/region; \"London\" is a proxy for the Greater London Authority"
         },
         "trees": {
           "additionalProperties": false,
@@ -25547,9 +25582,19 @@
           },
           "required": ["description"],
           "type": "object"
+        },
+        "ward": {
+          "description": "Name of the ward sourced from planning.data.gov.uk/dataset/ward",
+          "type": "string"
         }
       },
-      "required": ["address", "region", "localAuthorityDistrict", "type"],
+      "required": [
+        "address",
+        "localAuthorityDistrict",
+        "region",
+        "type",
+        "ward"
+      ],
       "type": "object"
     },
     "UKResidentialUnitType": {

--- a/src/export/digitalPlanning/schemas/application/types.d.ts
+++ b/src/export/digitalPlanning/schemas/application/types.d.ts
@@ -18,31 +18,18 @@ export type UserAddress =
     }
   | UserAddressNotSameSite;
 export type Email = string;
-/**
- * Contact information for the person(s) responsible for maintenance while the works are carried out
- */
-export type MaintenanceContacts = {
-  address: ContactAddress;
-  contact: ContactDetails;
-  when:
-    | "duringConstruction"
-    | "afterConstruction"
-    | "duringAndAfterConstruction";
-}[];
-export type OwnersInterest = "owner" | "lessee" | "occupier" | "other";
+export type OwnersInterest =
+  | "owner"
+  | "owner.sole"
+  | "owner.co"
+  | "lessee"
+  | "occupier"
+  | "other";
 export type Date = string;
 /**
  * Names and addresses of all known owners and agricultural tenants who are not the applicant, including confirmation or date of notice, or reason requisite notice has not been given if applicable
  */
 export type Owners = OwnersNoticeGiven | OwnersNoNoticeGiven | OwnersNoticeDate;
-/**
- * Contact information for the site visit
- */
-export type SiteContact =
-  | {
-      role: "applicant" | "agent" | "proxy";
-    }
-  | SiteContactOther;
 /**
  * Information about this planning application
  */
@@ -1479,7 +1466,7 @@ export type IntersectingPlanningDesignation =
       value: "watercourse.other";
     };
 /**
- * The region in England that contains this address sourced from planning.data.gov.uk/dataset/region, where 'London' is a proxy for the Greater London Authority (GLA) area
+ * Name of the region sourced from planning.data.gov.uk/dataset/region; "London" is a proxy for the Greater London Authority
  */
 export type Region =
   | "North East"
@@ -3967,6 +3954,19 @@ export type UKResidentialUnitType =
       description: "Studio or bedsit";
       value: "studio";
     };
+/**
+ * Name of the region sourced from planning.data.gov.uk/dataset/region; "London" is a proxy for the Greater London Authority
+ */
+export type Region1 =
+  | "North East"
+  | "North West"
+  | "Yorkshire and The Humber"
+  | "East Midlands"
+  | "West Midlands"
+  | "East of England"
+  | "London"
+  | "South East"
+  | "South West";
 export type LeadRegisteredSocialLandlord =
   | {
       description: string;
@@ -6099,7 +6099,14 @@ export interface BaseApplicant {
     name: string;
   };
   email: Email;
-  maintenanceContact?: MaintenanceContacts;
+  maintenanceContact?: {
+    address: ContactAddress;
+    contact: ContactDetails;
+    when:
+      | "duringConstruction"
+      | "afterConstruction"
+      | "duringAndAfterConstruction";
+  }[];
   name: {
     first: string;
     last: string;
@@ -6109,7 +6116,11 @@ export interface BaseApplicant {
   phone: {
     primary: string;
   };
-  siteContact: SiteContact;
+  siteContact:
+    | {
+        role: "applicant" | "agent" | "proxy";
+      }
+    | SiteContactOther;
   type: "individual" | "company" | "charity" | "public" | "parishCouncil";
 }
 /**
@@ -6167,7 +6178,7 @@ export interface Ownership {
   declaration?: {
     accurate: true;
   };
-  interest?: OwnersInterest | "owner.sole" | "owner.co";
+  interest?: OwnersInterest;
   interestDescription?: string;
   /**
    * Has requisite notice been given to all the known owners and agricultural tenants?
@@ -6238,7 +6249,14 @@ export interface Agent {
     name: string;
   };
   email: Email;
-  maintenanceContact?: MaintenanceContacts;
+  maintenanceContact?: {
+    address: ContactAddress;
+    contact: ContactDetails;
+    when:
+      | "duringConstruction"
+      | "afterConstruction"
+      | "duringAndAfterConstruction";
+  }[];
   name: {
     first: string;
     last: string;
@@ -6248,7 +6266,11 @@ export interface Agent {
   phone: {
     primary: string;
   };
-  siteContact: SiteContact;
+  siteContact:
+    | {
+        role: "applicant" | "agent" | "proxy";
+      }
+    | SiteContactOther;
   type: "individual" | "company" | "charity" | "public" | "parishCouncil";
 }
 export interface BaseApplicationData {
@@ -6680,6 +6702,9 @@ export interface FeatureCollection3CGeometry2CGeoJsonProperties3E {
  * Property details for sites anywhere in the UK
  */
 export interface UKProperty {
+  /**
+   * The property address
+   */
   address: ProposedSiteAddress | OSSiteAddress;
   boundary?: GeoBoundary1;
   /**
@@ -6729,6 +6754,10 @@ export interface UKProperty {
       lastUseEndDate: Date;
     };
   };
+  /**
+   * Name of the ward sourced from planning.data.gov.uk/dataset/ward
+   */
+  ward: string;
 }
 /**
  * Address information for sites without a known Unique Property Reference Number (UPRN)
@@ -6865,6 +6894,9 @@ export interface ResidentialUnits {
  */
 export interface LondonProperty {
   EPC?: EnergyPerformanceCertificate;
+  /**
+   * The property address
+   */
   address: ProposedSiteAddress | OSSiteAddress;
   boundary?: GeoBoundary2;
   /**
@@ -6908,7 +6940,7 @@ export interface LondonProperty {
      */
     sources: URL[];
   };
-  region: "London";
+  region: Region1;
   socialLandlord?: LeadRegisteredSocialLandlord;
   titleNumber?: {
     known: "Yes" | "No";
@@ -6932,6 +6964,10 @@ export interface LondonProperty {
       lastUseEndDate: Date;
     };
   };
+  /**
+   * Name of the ward sourced from planning.data.gov.uk/dataset/ward
+   */
+  ward: string;
 }
 export interface EnergyPerformanceCertificate {
   known:

--- a/src/export/digitalPlanning/schemas/preApplication/schema.json
+++ b/src/export/digitalPlanning/schemas/preApplication/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "v0.7.4",
+  "$id": "v0.7.5",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "definitions": {
@@ -101,7 +101,28 @@
           "$ref": "#/definitions/Email"
         },
         "maintenanceContact": {
-          "$ref": "#/definitions/MaintenanceContacts"
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "address": {
+                "$ref": "#/definitions/Address"
+              },
+              "contact": {
+                "$ref": "#/definitions/ContactDetails"
+              },
+              "when": {
+                "enum": [
+                  "duringConstruction",
+                  "afterConstruction",
+                  "duringAndAfterConstruction"
+                ],
+                "type": "string"
+              }
+            },
+            "required": ["when", "address", "contact"],
+            "type": "object"
+          },
+          "type": "array"
         },
         "name": {
           "additionalProperties": false,
@@ -133,7 +154,22 @@
           "type": "object"
         },
         "siteContact": {
-          "$ref": "#/definitions/SiteContact"
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "role": {
+                  "enum": ["applicant", "agent", "proxy"],
+                  "type": "string"
+                }
+              },
+              "required": ["role"],
+              "type": "object"
+            },
+            {
+              "$ref": "#/definitions/SiteContactOther"
+            }
+          ]
         },
         "type": {
           "enum": [
@@ -240,7 +276,22 @@
           "type": "object"
         },
         "siteContact": {
-          "$ref": "#/definitions/SiteContact"
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "role": {
+                  "enum": ["applicant", "agent", "proxy"],
+                  "type": "string"
+                }
+              },
+              "required": ["role"],
+              "type": "object"
+            },
+            {
+              "$ref": "#/definitions/SiteContactOther"
+            }
+          ]
         },
         "type": {
           "enum": [
@@ -2262,32 +2313,6 @@
       "required": ["coordinates", "type"],
       "type": "object"
     },
-    "MaintenanceContacts": {
-      "description": "Contact information for the person(s) responsible for maintenance while the works are carried out",
-      "items": {
-        "additionalProperties": false,
-        "properties": {
-          "address": {
-            "$ref": "#/definitions/Address"
-          },
-          "contact": {
-            "$ref": "#/definitions/ContactDetails"
-          },
-          "when": {
-            "enum": [
-              "duringConstruction",
-              "afterConstruction",
-              "duringAndAfterConstruction"
-            ],
-            "type": "string"
-          }
-        },
-        "required": ["when", "address", "contact"],
-        "type": "object"
-      },
-      "title": "Maintenance contacts",
-      "type": "array"
-    },
     "MultiLineString": {
       "additionalProperties": false,
       "description": "MultiLineString geometry object. https://tools.ietf.org/html/rfc7946#section-3.1.5",
@@ -2474,7 +2499,14 @@
       "title": "#Owners"
     },
     "OwnersInterest": {
-      "enum": ["owner", "lessee", "occupier", "other"],
+      "enum": [
+        "owner",
+        "owner.sole",
+        "owner.co",
+        "lessee",
+        "occupier",
+        "other"
+      ],
       "type": "string"
     },
     "OwnersNoNoticeGiven": {
@@ -2567,19 +2599,7 @@
           "type": "object"
         },
         "interest": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/OwnersInterest"
-            },
-            {
-              "const": "owner.sole",
-              "type": "string"
-            },
-            {
-              "const": "owner.co",
-              "type": "string"
-            }
-          ]
+          "$ref": "#/definitions/OwnersInterest"
         },
         "interestDescription": {
           "type": "string"
@@ -5939,7 +5959,8 @@
             {
               "$ref": "#/definitions/OSAddress"
             }
-          ]
+          ],
+          "description": "The property address"
         },
         "boundary": {
           "$ref": "#/definitions/GeoBoundary",
@@ -5974,13 +5995,24 @@
           "type": "object"
         },
         "region": {
-          "$ref": "#/definitions/Region"
+          "$ref": "#/definitions/Region",
+          "description": "Name of the region sourced from planning.data.gov.uk/dataset/region; \"London\" is a proxy for the Greater London Authority"
         },
         "type": {
           "$ref": "#/definitions/PropertyType"
+        },
+        "ward": {
+          "description": "Name of the ward sourced from planning.data.gov.uk/dataset/ward",
+          "type": "string"
         }
       },
-      "required": ["address", "region", "localAuthorityDistrict", "type"],
+      "required": [
+        "address",
+        "localAuthorityDistrict",
+        "region",
+        "type",
+        "ward"
+      ],
       "type": "object"
     },
     "PropertyType": {
@@ -15242,26 +15274,6 @@
       },
       "type": "array"
     },
-    "SiteContact": {
-      "anyOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "role": {
-              "enum": ["applicant", "agent", "proxy"],
-              "type": "string"
-            }
-          },
-          "required": ["role"],
-          "type": "object"
-        },
-        {
-          "$ref": "#/definitions/SiteContactOther"
-        }
-      ],
-      "description": "Contact information for the site visit",
-      "title": "Site contact"
-    },
     "SiteContactOther": {
       "additionalProperties": false,
       "description": "Contact information for the site visit when the SiteContact's role is 'other'",
@@ -15281,6 +15293,7 @@
         }
       },
       "required": ["role", "name", "email", "phone"],
+      "title": "Site contact other",
       "type": "object"
     },
     "URL": {

--- a/src/export/digitalPlanning/schemas/preApplication/types.d.ts
+++ b/src/export/digitalPlanning/schemas/preApplication/types.d.ts
@@ -18,26 +18,13 @@ export type UserAddress =
     }
   | UserAddressNotSameSite;
 export type Email = string;
-/**
- * Contact information for the site visit
- */
-export type SiteContact =
-  | {
-      role: "applicant" | "agent" | "proxy";
-    }
-  | SiteContactOther;
-/**
- * Contact information for the person(s) responsible for maintenance while the works are carried out
- */
-export type MaintenanceContacts = {
-  address: ContactAddress;
-  contact: ContactDetails;
-  when:
-    | "duringConstruction"
-    | "afterConstruction"
-    | "duringAndAfterConstruction";
-}[];
-export type OwnersInterest = "owner" | "lessee" | "occupier" | "other";
+export type OwnersInterest =
+  | "owner"
+  | "owner.sole"
+  | "owner.co"
+  | "lessee"
+  | "occupier"
+  | "other";
 export type Date = string;
 /**
  * Names and addresses of all known owners and agricultural tenants who are not the applicant, including confirmation or date of notice, or reason requisite notice has not been given if applicable
@@ -880,7 +867,7 @@ export type IntersectingPlanningDesignation =
     };
 export type URL = string;
 /**
- * The region in England that contains this address sourced from planning.data.gov.uk/dataset/region, where 'London' is a proxy for the Greater London Authority (GLA) area
+ * Name of the region sourced from planning.data.gov.uk/dataset/region; "London" is a proxy for the Greater London Authority
  */
 export type Region =
   | "North East"
@@ -3762,7 +3749,11 @@ export interface BasePreApplicant {
   phone: {
     primary: string;
   };
-  siteContact: SiteContact;
+  siteContact:
+    | {
+        role: "applicant" | "agent" | "proxy";
+      }
+    | SiteContactOther;
   type: "individual" | "company" | "charity" | "public" | "parishCouncil";
 }
 /**
@@ -3810,7 +3801,14 @@ export interface Agent {
     name: string;
   };
   email: Email;
-  maintenanceContact?: MaintenanceContacts;
+  maintenanceContact?: {
+    address: ContactAddress;
+    contact: ContactDetails;
+    when:
+      | "duringConstruction"
+      | "afterConstruction"
+      | "duringAndAfterConstruction";
+  }[];
   name: {
     first: string;
     last: string;
@@ -3820,7 +3818,11 @@ export interface Agent {
   phone: {
     primary: string;
   };
-  siteContact: SiteContact;
+  siteContact:
+    | {
+        role: "applicant" | "agent" | "proxy";
+      }
+    | SiteContactOther;
   type: "individual" | "company" | "charity" | "public" | "parishCouncil";
 }
 /**
@@ -3866,7 +3868,7 @@ export interface Ownership {
   declaration?: {
     accurate: true;
   };
-  interest?: OwnersInterest | "owner.sole" | "owner.co";
+  interest?: OwnersInterest;
   interestDescription?: string;
   /**
    * Has requisite notice been given to all the known owners and agricultural tenants?
@@ -3958,6 +3960,9 @@ export interface Declaration {
   };
 }
 export interface Property {
+  /**
+   * The property address
+   */
   address: ProposedSiteAddress | OSSiteAddress;
   boundary?: GeoBoundary;
   /**
@@ -3976,6 +3981,10 @@ export interface Property {
   };
   region: Region;
   type: PropertyType;
+  /**
+   * Name of the ward sourced from planning.data.gov.uk/dataset/ward
+   */
+  ward: string;
 }
 /**
  * Address information for sites without a known Unique Property Reference Number (UPRN)


### PR DESCRIPTION
Adds `ward` to payload following on from https://github.com/theopensystemslab/planx-new/pull/4703

This version won't be live on BOPS staging until at least Friday, May 30 https://opendigitalplanning.slack.com/archives/C0182MVK4AW/p1748510113789459?thread_ts=1748341617.208289&cid=C0182MVK4AW

Will add support for third, independent "enforcement" schema in follow-up future PR.