### PR TITLE
fix: correct redaction for single-line `ContactInput` transformation in `proposal_details`

### DIFF
--- a/src/export/bops/index.ts
+++ b/src/export/bops/index.ts
@@ -234,6 +234,12 @@ export function formatProposalDetails({
             const contactObject = Object.values(crumb.data!).filter(
               (x) => typeof x === "object",
             )[0];
+
+            // Get the "fn" of this component if present
+            const fn = Object.entries(crumb.data!)
+              .filter(([_k, v]) => typeof v === "object")[0][0]
+              ?.split("_contact.")[1];
+
             // Get _contact nested entries indpendent of the outer `fn` property set by the flow node
             const contactParts = Object.values(contactObject!).filter(
               (y) => typeof y === "object",
@@ -250,7 +256,23 @@ export function formatProposalDetails({
             ];
             const orderedContactItems: string[] = [];
             orderedContactKeys.forEach((key) => {
-              if (contactParts?.[key]) {
+              // If keysToRedact are present, redact "parts"
+              if (contactParts?.[key] && keysToRedact) {
+                const orderedContactKeysPassportMap = {
+                  title: `${fn}.title`,
+                  firstName: `${fn}.name.first`,
+                  lastName: `${fn}.name.last`,
+                  organisation: `${fn}.company.name`,
+                  phone: `${fn}.phone.primary`,
+                  email: `${fn}.email`,
+                };
+
+                if (keysToRedact.includes(orderedContactKeysPassportMap[key])) {
+                  orderedContactItems.push("REDACTED");
+                } else {
+                  orderedContactItems.push(contactParts?.[key]);
+                }
+              } else if (contactParts?.[key]) {
                 orderedContactItems.push(contactParts?.[key]);
               }
             });

--- a/src/export/bops/tests/contactInput.test.ts
+++ b/src/export/bops/tests/contactInput.test.ts
@@ -112,4 +112,66 @@ describe("ContactInput details are set correctly based on the breadcrumbs", () =
       }),
     );
   });
+
+  it("redacts form components correctly for `applicant`", () => {
+    const generatedPayload = computeBOPSParams({
+      ...testParams,
+      keysToRedact: ["applicant.phone.primary", "applicant.email"],
+    });
+
+    const proposalDetails = generatedPayload.proposal_details;
+    const contactInputItem = proposalDetails?.filter(
+      (detail) => detail.question === "Your contact details",
+    )?.[0];
+
+    expect(contactInputItem?.responses[0]).toEqual(
+      expect.objectContaining({
+        value: "Ms Jane Doe Open Systems Lab REDACTED REDACTED",
+      }),
+    );
+  });
+
+  it("redacts form components correctly for `applicant.agent`", () => {
+    const generatedPayload = computeBOPSParams({
+      ...testParams,
+      breadcrumbs: {
+        DQl19JOA9y: {
+          auto: false,
+          data: {
+            "_contact.applicant.agent": {
+              applicant: {
+                firstName: "Mister",
+                lastName: "Agent",
+                organisation: "Planning Agency LLC",
+                phone: "0123456789",
+                email: "test@test.com",
+              },
+            },
+            "applicant.agent.name.first": "Mister",
+            "applicant.agent.name.last": "Agent",
+            "applicant.agent.company.name": "Planning Agency LLC",
+            "applicant.agent.phone.primary": "0123456789",
+            "applicant.agent.email": "test@test.com",
+          },
+        },
+      },
+      keysToRedact: [
+        "applicant.agent.name.first",
+        "applicant.agent.name.last",
+        "applicant.agent.phone.primary",
+        "applicant.agent.email",
+      ],
+    });
+
+    const proposalDetails = generatedPayload.proposal_details;
+    const contactInputItem = proposalDetails?.filter(
+      (detail) => detail.question === "Your contact details",
+    )?.[0];
+
+    expect(contactInputItem?.responses[0]).toEqual(
+      expect.objectContaining({
+        value: "REDACTED REDACTED Planning Agency LLC REDACTED REDACTED",
+      }),
+    );
+  });
 });

--- a/src/export/bops/tests/payload.test.ts
+++ b/src/export/bops/tests/payload.test.ts
@@ -62,6 +62,7 @@ describe("computeBOPSParams", () => {
 
     it("excludes redacted keys and payment details", () => {
       // check the response shape excluding proposal_details as order can vary
+      //   NOTE THAT THIS DOES NOT TEST REDACTION OF 'ContactInput' QUESTIONS AND 'ANSWERS' !!
       const generatedMinimumPayload = omit(redactedPayload, [
         "proposal_details",
       ]);


### PR DESCRIPTION
See #help-issues report from Gateshead here https://opendigitalplanning.slack.com/archives/C0241GWFG4B/p1749033657201129