### PR TITLE
fix: update default redaction keys for `siteContact`

### DIFF
--- a/src/export/index.ts
+++ b/src/export/index.ts
@@ -125,7 +125,9 @@ export async function generateBOPSPayload({
         "applicant.agent.phone.primary",
         "applicant.agent.phone.secondary",
         "applicant.agent.email",
-        "applicant.siteContact.telephone",
+        "applicant.siteContact.telephone", // legacy TextInput use?
+        "applicant.siteContact.phone.primary", // new ContactInput use
+        "applicant.siteContact.phone.secondary",
         "applicant.siteContact.email",
       ];
       const redactedExportData = computeBOPSParams({


### PR DESCRIPTION
See #help-issues report from Alfie at West Berks: https://opendigitalplanning.slack.com/archives/C0241GWFG4B/p1750078826705569

This was the session in question using `applicant.siteContact.phone.primary` (no such thing as `applicant.siteContact.phone.secondary` but not removing right now just in case used in discretionary services still?): https://api.editor.planx.uk/admin/session/5dd54413-22c3-4011-93b8-55ff4fe2ebca/summary