### PR TITLE
fix: account for WTT in schema `preAssessment` mappings

### DIFF
--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -895,6 +895,7 @@ export class DigitalPlanning {
     // Planning Permission application types won't have a Planning Permission result right now
     if (
       this.applicationType?.startsWith("pp") ||
+      this.applicationType?.startsWith("wtt") ||
       this.applicationType === "listed" ||
       this.applicationType === "ldc.listedBuildingWorks"
     ) {
@@ -910,7 +911,8 @@ export class DigitalPlanning {
       return [
         {
           value: title,
-          description: this.findDescriptionFromValue("ResultFlag", title), // flag.description may be custom text
+          description:
+            this.findDescriptionFromValue("ResultFlag", title) || "Unknown", // flag.description may be custom text
         },
       ] as ApplicationPayload["preAssessment"];
     }


### PR DESCRIPTION
See bug thread https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1750416181557719

Both: 
- Skips setting a `preAssessment` if application type starts with `WTT`
- Sets fallback "Unknown" description so that in future payloads don't fail on unrecognised flag values

Eventually switching to `prototypeApplication` will be longterm solution here, but this should ease some validation errors now :crossed_fingers: 