### PR TITLE
chore: Export `FlagSet` values, not just types

### DIFF
--- a/src/types/flags.ts
+++ b/src/types/flags.ts
@@ -1,11 +1,14 @@
-export type FlagSet =
-  | "Planning permission"
-  | "Works to listed buildings"
-  | "Works to trees & hedges"
-  | "Demolition in a conservation area"
-  | "Planning policy"
-  | "Community infrastructure levy"
-  | "Material change of use";
+export const FLAG_SETS = [
+  "Planning permission",
+  "Works to listed buildings",
+  "Works to trees & hedges",
+  "Demolition in a conservation area",
+  "Planning policy",
+  "Community infrastructure levy",
+  "Material change of use",
+] as const;
+
+export type FlagSet = (typeof FLAG_SETS)[number];
 
 export const DEFAULT_FLAG_CATEGORY: FlagSet = "Planning permission";
 


### PR DESCRIPTION
This repeats the patterns used for `const NODE_TAGS` and `type NodeTags`, allowing us access to the underlying values as well as the types.

Implemented in https://github.com/theopensystemslab/planx-new/pull/4909