### PR TITLE
feat: add `teamAdmin` role

### DIFF
--- a/src/types/roles.ts
+++ b/src/types/roles.ts
@@ -2,9 +2,9 @@
  * Roles which grant users a set of permissions for a particular team
  * Stored in the user_roles table, these confer Hasura roles of the same names to a users's JWT
  *
- * teamAdmin: Full permissions for a particular team, read access to all others
+ * teamAdmin: Full service, team, and subscription management permissions for a particular team, read access to all others
  *
- * teamEditor: Full permissions for a particular team excluding "My subscription" page, read access to all others
+ * teamEditor: Full service management permissions for a particular team, read access to all others
  *
  * teamViewer: Read-only access to a team
  *

--- a/src/types/roles.ts
+++ b/src/types/roles.ts
@@ -2,7 +2,7 @@
  * Roles which grant users a set of permissions for a particular team
  * Stored in the user_roles table, these confer Hasura roles of the same names to a users's JWT
  *
- * teamAdmin: Full permissiosn for a particular team, read access to all others
+ * teamAdmin: Full permissions for a particular team, read access to all others
  *
  * teamEditor: Full permissions for a particular team excluding "My subscription" page, read access to all others
  *

--- a/src/types/roles.ts
+++ b/src/types/roles.ts
@@ -2,13 +2,15 @@
  * Roles which grant users a set of permissions for a particular team
  * Stored in the user_roles table, these confer Hasura roles of the same names to a users's JWT
  *
- * teamEditor: Full permissions for a particular team, read access to all others
+ * teamAdmin: Full permissiosn for a particular team, read access to all others
+ *
+ * teamEditor: Full permissions for a particular team excluding "My subscription" page, read access to all others
  *
  * teamViewer: Read-only access to a team
  *
  * demoUser: Can only see their own flows in Demo team, and read-only access to Templates, ODP, and OSL teams
  */
-export type TeamRole = "teamEditor" | "teamViewer" | "demoUser";
+export type TeamRole = "teamAdmin" | "teamEditor" | "teamViewer" | "demoUser";
 
 /**
  * General roles used by Hasura


### PR DESCRIPTION
See https://github.com/theopensystemslab/planx-new/pull/4932

Now _describing_ permissions as follows (building this still TODO!):
- Service management (eg all features now) = `teamEditor` & `teamAdmin`
- Team management (eg add/update/remove members) = `teamAdmin` only
-  Subscription management (eg view service charges in editor & PlanX contract info) = `teamAdmin` only