### PR TITLE
fix(digital-planning-application): Correctly map submitted date, not current date

### DIFF
--- a/src/export/digitalPlanning/model.test.ts
+++ b/src/export/digitalPlanning/model.test.ts
@@ -35,7 +35,7 @@ const mockMetadataForSession = (
 ): SessionMetadata => ({
   id: "c06eebb7-6201-4bc0-9fe7-ec5d7a1c0797",
   createdAt: "2023-01-01 00:00:00",
-  submittedAt: "2023-01-02 00:00:00",
+  submittedAt: "2023-01-02T12:17:33.199914+00:00",
   flow: {
     id: "c06eebb7-6201-4bc0-9fe7-ec5d7a1c0797",
     slug: "apply-for-a-test-service",

--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -1444,7 +1444,7 @@ export class DigitalPlanning {
     return {
       id: this.sessionId,
       organisation: this.metadata.flow.team.settings.referenceCode,
-      submittedAt: new Date().toISOString(),
+      submittedAt: this.metadata.submittedAt,
       source: "PlanX",
       service: {
         flowId: this.metadata.flow.id,


### PR DESCRIPTION
## What does this PR do?
Updates the `metadata.submittedAt` field for the Digital Planning Application payload to reference the original submission date, and not the current date.

## What's the problem?
(From memory) I believe the original motivation here was to acknowledge that user submission and PlanX submission are two distinct events - consumers should care about when _we_ send it (e.g. in the case of failures, retries etc).

I can't find a reference to this in the git blame, just this PR when it was introduced https://github.com/theopensystemslab/planx-core/pull/210

However, I think that this mental model of two submission events doesn't really hold up now that we have send to email and the ability to download from the Editor. Each time this happens a new (current) date is used for the payload 🐛 

If we were to generate a static payload on submission, store somewhere (e.g. S3) and then retrieve this data we could (and should) revert to `new Date()`. As the payload is generated at runtime, we're better sticking to the canonical `lowcal_session.submitted_at` even if not 100% accurate in all cases.