### PR TITLE
fix: Use fallback value for `metadata.submittedAt`

### DIFF
--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -1444,7 +1444,8 @@ export class DigitalPlanning {
     return {
       id: this.sessionId,
       organisation: this.metadata.flow.team.settings.referenceCode,
-      submittedAt: this.metadata.submittedAt,
+      // A fallback is required as this value is not populated until after the first submission
+      submittedAt: this.metadata.submittedAt || new Date().toISOString(),
       source: "PlanX",
       service: {
         flowId: this.metadata.flow.id,


### PR DESCRIPTION
Follow up and fix for https://github.com/theopensystemslab/planx-core/pull/831

The first time a payload is generated, `lowcal_session.submitted_at` will not be populated. In these cases, use the current time. For all future times the payload is generated, we can rely on the original submission date.
