### PR TITLE
fix: Add fallback value for preApplication fee payable

### DIFF
--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -200,7 +200,8 @@ export class DigitalPlanning {
             description: "Pre-application",
           },
           fee: {
-            payable: this.passport.data?.["application.fee.payable"] as number,
+            payable:
+              (this.passport.data?.["application.fee.payable"] as number) || 0,
             // Account for self-pay (has passport data) or invite to pay (has govUkPayment only)
             ...((this.passport.data?.["application.fee.reference.govPay"] ||
               this.govUkPayment) && {


### PR DESCRIPTION
## What's the problem?
For a pre application payload, a the `data.application.fee.payable` value is required. See schema definition here - https://github.com/theopensystemslab/digital-planning-data-schemas/blob/main/schemas/preApplication.json#L6890-L6915

Setting a fallback will mean that applications without fees will still generate valid payloads.

## Questions / thoughts
Currently, the `metadata` object handles this more gracefully - allowing either a `FeeExplanation` or `FeeExplanationNotApplicable`. It might be more consistent to consider a similar pattern within `data.application.fee` in future iterations.