### PR TITLE
chore: remove external_planning_site from getBySlug query

### DIFF
--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -242,8 +242,6 @@ async function getBySlug(client: GraphQLClient, slug: string) {
             helpOpeningHours: help_opening_hours
             emailReplyToId: email_reply_to_id
             homepage: homepage
-            externalPlanningSiteName: external_planning_site_name
-            externalPlanningSiteUrl: external_planning_site_url
           }
         }
       }


### PR DESCRIPTION
Missed in #974 