### PR TITLE
fix: only record gov pay reference number on "success"

### DIFF
--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -17,6 +17,7 @@ import {
   Passport as IPassport,
   SessionMetadata,
   Value,
+  PaymentStatus,
 } from "../../types/index.js";
 import { getFeeBreakdown } from "../../utils/index.js";
 import {
@@ -871,7 +872,7 @@ export class DigitalPlanning {
       paymentProcessingVAT: feeBreakdown.amount.paymentProcessingVAT,
       // Account for self-pay (has passport data) or invite to pay (has govUkPayment only)
       ...((this.passport.data?.["application.fee.reference.govPay"] ||
-        this.govUkPayment) && {
+        (this.govUkPayment && this.govUkPayment.state.status === PaymentStatus.success)) && {
         reference: {
           govPay:
             this.passport.data?.["application.fee.reference.govPay"]?.[

--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -872,7 +872,8 @@ export class DigitalPlanning {
       paymentProcessingVAT: feeBreakdown.amount.paymentProcessingVAT,
       // Account for self-pay (has passport data) or invite to pay (has govUkPayment only)
       ...((this.passport.data?.["application.fee.reference.govPay"] ||
-        (this.govUkPayment && this.govUkPayment.state.status === PaymentStatus.success)) && {
+        (this.govUkPayment &&
+          this.govUkPayment.state.status === PaymentStatus.success)) && {
         reference: {
           govPay:
             this.passport.data?.["application.fee.reference.govPay"]?.[

--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -1,5 +1,5 @@
-import { default as addFormats } from "ajv-formats/dist/index.js";
 import { default as Ajv } from "ajv/dist/ajv.js";
+import { default as addFormats } from "ajv-formats/dist/index.js";
 import { Feature } from "geojson";
 import { set } from "lodash-es";
 
@@ -13,8 +13,8 @@ import {
   EnhancedGISResponse,
   FlowGraph,
   GovUKPayment,
-  Passport as IPassport,
   Node,
+  Passport as IPassport,
   PaymentStatus,
   SessionMetadata,
   Value,

--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -1,5 +1,5 @@
-import { default as Ajv } from "ajv/dist/ajv.js";
 import { default as addFormats } from "ajv-formats/dist/index.js";
+import { default as Ajv } from "ajv/dist/ajv.js";
 import { Feature } from "geojson";
 import { set } from "lodash-es";
 
@@ -13,11 +13,11 @@ import {
   EnhancedGISResponse,
   FlowGraph,
   GovUKPayment,
-  Node,
   Passport as IPassport,
+  Node,
+  PaymentStatus,
   SessionMetadata,
   Value,
-  PaymentStatus,
 } from "../../types/index.js";
 import { getFeeBreakdown } from "../../utils/index.js";
 import {


### PR DESCRIPTION
We had at least two payloads that incorrectly recorded a non-successful Gov UK Pay reference number. See this thread: https://opensystemslab.slack.com/archives/C088K9ZL8EA/p1777306960440849

`reference` is optional in the schema, and we don't want to over-eagerly populate here! It should only be populated on cases of payment "success", which means it's a reference number that councils will _actually_ see in their finance dashboard too.