### PR TITLE
fix: add optional `cachedBreadcrumbs` to `SessionData` type

### DIFF
--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -10,6 +10,7 @@ export type Passport = {
 export type SessionData = {
   passport: Passport;
   breadcrumbs: Breadcrumbs;
+  cachedBreadcrumbs?: Breadcrumbs; // only if "back" navigation is applicable
   govUkPayment?: GovUKPayment;
   id: string; // flowId
 };


### PR DESCRIPTION
This needs to stay aligned with https://github.com/theopensystemslab/planx-new/pull/6542

- Editor relies on `Store.CachedBreadcrumbs` type
- E2E imports `SessionData` type from here / planx-core