### PR TITLE
fix: condition 'Paid' wording on pay reference

### DIFF
--- a/src/templates/html/application/ApplicationHTML.tsx
+++ b/src/templates/html/application/ApplicationHTML.tsx
@@ -123,7 +123,7 @@ function Highlights(props: {
             <dd>{payRef && <CopyButton value={payRef} />}</dd>
           </React.Fragment>
           <React.Fragment key={"fee"}>
-            <dt>Fee paid</dt>
+            <dt>{payRef ? "Fee paid" : "Fee payable"}</dt>
             <dd>{typeof feePaid === "number" && `£${feePaid.toFixed(2)}`}</dd>
             <dd>
               {typeof feePaid === "number" && (
@@ -134,7 +134,7 @@ function Highlights(props: {
         </>
       )}
       <React.Fragment key={"createdDate"}>
-        <dt>{feeCarrying ? "Paid and submitted on" : "Submitted on"}</dt>
+        <dt>{payRef ? "Paid and submitted on" : "Submitted on"}</dt>
         <dd>{submittedAt}</dd>
         <dd>
           <CopyButton value={submittedAt} />


### PR DESCRIPTION
We want to avoid suggesting we know whether or not a fee was already paid if we don't have a GOV pay reference, e.g. due to external payment. This conditions the 'paid' wording in the overview.htm on payRef, defaulting to 'payable' or 'submitted' wording if we don't.