### PR TITLE
chore: refactor `sortBreadcrumbs` to sort on `seq` instead of depth-first

### DIFF
--- a/src/models/session/logic.ts
+++ b/src/models/session/logic.ts
@@ -70,36 +70,9 @@ export function sortBreadcrumbs(
   flow: FlowGraph,
   breadcrumbs: Breadcrumbs,
 ): OrderedBreadcrumbs {
-  const breadcrumbMap = new Map(Object.entries(breadcrumbs));
-  const breadcrumbsInOrder = new Map<NodeId, Crumb>();
-
-  const visited = new Set<NodeId>();
-  const stack: string[] = [...(flow._root.edges || [])].reverse();
-
-  while (stack.length > 0) {
-    const id = stack.pop()!;
-
-    if (visited.has(id)) continue;
-    visited.add(id);
-
-    const currentNode = flow[id];
-    const crumb = breadcrumbMap.get(id);
-
-    // Track crumbs in order (by flow depth)
-    if (crumb) breadcrumbsInOrder.set(id, crumb);
-
-    if (!currentNode?.edges) continue;
-
-    // Node edges are traversed left-to-right
-    // We process our stack in last-in, first-out order
-    // This means we need to iterate backwards over edges
-    for (let i = currentNode.edges.length - 1; i >= 0; i--) {
-      const childId = currentNode.edges[i];
-      if (!visited.has(childId)) {
-        stack.push(childId);
-      }
-    }
-  }
+  const breadcrumbsInOrder: Map<NodeId, Crumb> = new Map(
+    Object.entries(breadcrumbs).sort(([, a], [, b]) => a.seq! - b.seq!),
+  );
 
   const orderedBreadcrumbs: OrderedBreadcrumbs = [];
   let currentSectionId: NodeId | undefined = undefined;

--- a/src/models/session/mocks/complex-flow-breadcrumbs.ts
+++ b/src/models/session/mocks/complex-flow-breadcrumbs.ts
@@ -782,28 +782,35 @@ export const breadcrumbs: Breadcrumbs = {
   Imks7j68BD: {
     auto: false,
     answers: ["EqfqaqZ6CH", "pXFKKRG6lE"],
+    seq: 1,
   },
   HV0gV8DOil: {
     answers: ["lTosE7Xo1j", "0LzMSk4JTO"],
     auto: true,
+    seq: 2,
   },
   "2PT6bTPTqj": {
     answers: ["U9S73zxy9n"],
     auto: true,
+    seq: 3,
   },
   t3SCqQKeUK: {
     auto: false,
+    seq: 4,
   },
   "3H2bGdzpIN": {
     answers: ["BJpKurp49I"],
     auto: true,
+    seq: 5,
   },
   AFX3QwbOCd: {
     answers: ["0vojjvJ6rP"],
     auto: true,
+    seq: 6,
   },
   mOPogpQa7V: {
     auto: false,
+    seq: 7,
   },
 };
 

--- a/src/models/session/mocks/section-flow-breadcrumbs.ts
+++ b/src/models/session/mocks/section-flow-breadcrumbs.ts
@@ -296,24 +296,30 @@ export const sectionNodes: NormalizedFlow = [
 export const breadcrumbs: Breadcrumbs = {
   firstSection: {
     auto: false,
+    seq: 1,
   },
   firstQuestion: {
     auto: false,
     answers: ["firstAnswer"],
+    seq: 2,
   },
   secondSection: {
     auto: false,
+    seq: 3,
   },
   secondQuestion: {
     auto: false,
     answers: ["secondAnswer"],
+    seq: 4,
   },
   thirdSection: {
     auto: false,
+    seq: 5,
   },
   thirdQuestion: {
     auto: false,
     answers: ["thirdAnswer"],
+    seq: 6,
   },
 };
 

--- a/src/models/session/mocks/simple-flow-breadcrumbs.ts
+++ b/src/models/session/mocks/simple-flow-breadcrumbs.ts
@@ -170,14 +170,17 @@ export const breadcrumbs: Breadcrumbs = {
   firstQuestion: {
     auto: false,
     answers: ["firstAnswer"],
+    seq: 1,
   },
   secondQuestion: {
     auto: false,
     answers: ["secondAnswer"],
+    seq: 2,
   },
   thirdQuestion: {
     auto: false,
     answers: ["thirdAnswer"],
+    seq: 3,
   },
 };
 

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -37,6 +37,7 @@ export type Crumb = {
   data?: DataObject;
   override?: DataObject;
   feedback?: string;
+  seq?: number;
 };
 
 export type Breadcrumbs = {


### PR DESCRIPTION
Follows on from https://github.com/theopensystemslab/planx-new/pull/6844

Todo: 
- [x] Update `sortBreadcrumbs`
- [x] Manually update small test mocks to add `seq`
- [ ] Regenerate all full-service flow + session data mocks (eg `/src/export/digitalPlanning/mocks`) to reflect `seq`
  - Honestly is this worth it?? We could refactor function to sort on `seq` if exists (will apply to all "real" data) or keep depth-first traversal if `seq` undefined (will apply to all "mock" data) ?? Obviously makes tests a lot less useful/thorough here, but not an easy or quick task to regenerate across flows/services !!