### PR TITLE
fix: rename `team_members` constraint

### DIFF
--- a/src/requests/team.ts
+++ b/src/requests/team.ts
@@ -177,7 +177,7 @@ export async function upsertMember(
           insert_team_members_one(
             object: { team_id: $team_id, user_id: $user_id, role: $role }
             on_conflict: {
-              constraint: team_members_user_id_team_id_key
+              constraint: team_members_user_id_team_id_role_key
               update_columns: role
             }
           ) {


### PR DESCRIPTION
Hard-coded constraint was updated in teamAdmin work, this was the culprit for [failing e2e regression tests](https://github.com/theopensystemslab/planx-new/actions/runs/28154081895/job/83384907661). 