### PR TITLE
chore: Move MUI to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,10 +52,7 @@
     "trace:clean": "rimraf .traces"
   },
   "dependencies": {
-    "@emotion/react": "^11.14.0",
-    "@emotion/styled": "^11.14.1",
     "@formatjs/intl-listformat": "^8.3.8",
-    "@mui/material": "<9.1.0",
     "ajv-formats": "^2.1.1",
     "ajv": "^8.18.0",
     "cheerio": "1.2.0",
@@ -75,6 +72,9 @@
   "devDependencies": {
     "react-dom": "^19.2.4",
     "react": "^19.2.4",
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
+    "@mui/material": "<9.1.0",
     "@types/geojson": "^7946.0.16",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "~24.10.15",
@@ -93,6 +93,9 @@
     "vitest": "^4.1.8"
   },
   "peerDependencies": {
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
+    "@mui/material": "<9.1.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,18 +12,9 @@ importers:
 
   .:
     dependencies:
-      '@emotion/react':
-        specifier: ^11.14.0
-        version: 11.14.0(@types/react@19.2.17)(react@19.2.4)
-      '@emotion/styled':
-        specifier: ^11.14.1
-        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.4))(@types/react@19.2.17)(react@19.2.4)
       '@formatjs/intl-listformat':
         specifier: ^8.3.8
         version: 8.3.10
-      '@mui/material':
-        specifier: <9.1.0
-        version: 9.0.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.4))(@types/react@19.2.17)(react@19.2.4))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ajv:
         specifier: ^8.18.0
         version: 8.20.0
@@ -70,6 +61,15 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
+      '@emotion/react':
+        specifier: ^11.14.0
+        version: 11.14.0(@types/react@19.2.17)(react@19.2.4)
+      '@emotion/styled':
+        specifier: ^11.14.1
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.4))(@types/react@19.2.17)(react@19.2.4)
+      '@mui/material':
+        specifier: <9.1.0
+        version: 9.0.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.4))(@types/react@19.2.17)(react@19.2.4))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/geojson':
         specifier: ^7946.0.16
         version: 7946.0.16


### PR DESCRIPTION
Follow up to #1024 based on [this comment](https://github.com/theopensystemslab/planx-core/pull/1024#pullrequestreview-4627514677).

This PR moves MUI packages to be peer and dev dependencies to avoid package conflicts in a monorepo setup. This should also solve our problem of having to match the exact package version numbers as we've had to in the past (e.g. [here](https://github.com/theopensystemslab/planx-core/pull/968) or [here](https://github.com/theopensystemslab/planx-core/pull/654))