### PR TITLE
fix: don't throw error on missing session preview keys

### DIFF
--- a/src/requests/payment-request.test.ts
+++ b/src/requests/payment-request.test.ts
@@ -23,31 +23,6 @@ describe("extractSessionPreviewData", () => {
     );
   });
 
-  test("keys must be present in the passport", () => {
-    const invalidSession: Session = {
-      id: "abc",
-      data: {
-        id: "flow-abc",
-        passport: {
-          data: {
-            key1: "a",
-          },
-        },
-        breadcrumbs: {},
-      },
-      flow: {
-        id: "flow-abc",
-        slug: "apply-for-something",
-        name: "Apply for Something",
-        email_template: "application",
-      },
-    };
-    const previewKeys: KeyPath[] = [["key1"], ["key2", "notFoundKey"]];
-    expect(() =>
-      extractSessionPreviewData(invalidSession, previewKeys),
-    ).toThrow('passport key "key2.notFoundKey" not found in passport data');
-  });
-
   test("a simple set of session preview keys are extracted from the session", () => {
     const session: Session = {
       id: "abc",

--- a/src/requests/payment-request.ts
+++ b/src/requests/payment-request.ts
@@ -185,12 +185,7 @@ export function extractSessionPreviewData(
   }
   const sessionPreviewData: PaymentRequest["sessionPreviewData"] = {};
   sessionPreviewKeys.forEach((keyPath: KeyPath) => {
-    if (!passport.has(keyPath)) {
-      throw new Error(
-        `passport key "${keyPath.join(".")}" not found in passport data`,
-      );
-    }
-    const value = passport.any(keyPath);
+    const value = passport.has(keyPath) ? passport.any(keyPath) : "Not submitted";
     setByKeyPath(sessionPreviewData, keyPath, value as Value);
   });
   return sessionPreviewData;

--- a/src/requests/payment-request.ts
+++ b/src/requests/payment-request.ts
@@ -185,7 +185,9 @@ export function extractSessionPreviewData(
   }
   const sessionPreviewData: PaymentRequest["sessionPreviewData"] = {};
   sessionPreviewKeys.forEach((keyPath: KeyPath) => {
-    const value = passport.has(keyPath) ? passport.any(keyPath) : "Not submitted";
+    const value = passport.has(keyPath)
+      ? passport.any(keyPath)
+      : "Not submitted";
     setByKeyPath(sessionPreviewData, keyPath, value as Value);
   });
   return sessionPreviewData;


### PR DESCRIPTION
See thread https://opensystemslab.slack.com/archives/C4B0CKQ3U/p1783504433807739

Airbrake has been logging a number of 
```
Error: could not initiate a payment request: passport key "proposal.projectType" not found in passport data
```
despite removing this requirment from publish validation checks and simply allowing ITP emails and summary page to fallback to "Not submitted". We need to similarly loosen this requirement here.

There are now too many discretionary fee-carrying services to reasonably enforce these summary keys.