### PR TITLE
Revert "fix: handle "No result" flags in ODP Schema `preAssessment` mappings"

### DIFF
--- a/src/export/digitalPlanning/model.ts
+++ b/src/export/digitalPlanning/model.ts
@@ -1030,8 +1030,6 @@ export class DigitalPlanning {
       const flag = result?.[DEFAULT_FLAG_CATEGORY]?.["flag"];
       const title = [flag.category, flag.text].join(" / ");
 
-      if (flag.text === "No result") return undefined;
-
       return [
         {
           value: title,


### PR DESCRIPTION
Reverts theopensystemslab/planx-core#1044

This temporarily validated a broken submission, but we want to continue throwing these errors to fix broken content journeys! 